### PR TITLE
feat: OAuth 연동 정보 DB 저장 및 소셜 로그인 분기 처리 (#38)

### DIFF
--- a/src/main/java/com/gathering/auth/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/gathering/auth/application/CustomOAuth2UserService.java
@@ -1,18 +1,23 @@
 package com.gathering.auth.application;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.gathering.auth.domain.OAuthPrincipal;
 import com.gathering.auth.domain.OAuthUserInfo;
 import com.gathering.common.exception.BusinessException;
 import com.gathering.common.exception.ErrorCode;
 import com.gathering.user.application.UserService;
+import com.gathering.user.domain.model.UserOAuthConnectionEntity;
+import com.gathering.user.domain.model.UsersEntity;
+import com.gathering.user.domain.repository.UserOAuthConnectionRepository;
 import com.gathering.user.domain.repository.UsersRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -23,21 +28,71 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 	private final UserService userService;
 	private final UsersRepository usersRepository;
+	private final UserOAuthConnectionRepository oauthConnectionRepository;
 
 	@Override
+	@Transactional
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
-		Map<String, Object> attributes = super.loadUser(userRequest).getAttributes();
+		// 1. OAuth 제공자로부터 사용자 정보 추출
+		Map<String, Object> attributes = callSuperLoadUser(userRequest).getAttributes();
 
 		OAuthUserInfo oAuthUserInfo = OAuthUserInfo.of(
 			userRequest.getClientRegistration().getRegistrationId(),
 			attributes
 		);
 
-		if (usersRepository.findByEmail(oAuthUserInfo.getEmail()).isPresent()) {
-			throw new BusinessException(ErrorCode.EMAIL_ALREADY_REGISTERED);
+		// 2. 기존 연동 정보 확인 (provider + providerId)
+		Optional<UserOAuthConnectionEntity> existingConnection =
+			oauthConnectionRepository.findByProviderAndProviderId(
+				oAuthUserInfo.getProvider(),
+				oAuthUserInfo.getProviderId()
+			);
+
+		if (existingConnection.isPresent()) {
+			// 2-1. 이미 연동된 계정 → 로그인 처리
+			return handleExistingOAuthConnection(existingConnection.get(), attributes);
 		}
 
-		return new OAuthPrincipal(userService.socialJoin(oAuthUserInfo), attributes);
+		// 3. 이메일로 기존 사용자 확인
+		Optional<UsersEntity> existingUser = usersRepository.findByEmail(oAuthUserInfo.getEmail());
+
+		if (existingUser.isPresent()) {
+			// 3-2. 이메일로 가입된 다른 계정 → 에러
+			throw new BusinessException(ErrorCode.OAUTH_DIFFERENT_ACCOUNT);
+		}
+
+		// 3-1. 신규 회원가입 + 소셜 연동 정보 저장
+		return handleNewOAuthUser(oAuthUserInfo, attributes);
+	}
+
+	/**
+	 * 테스트를 위해 super.loadUser() 호출을 별도 메서드로 분리
+	 */
+	protected OAuth2User callSuperLoadUser(OAuth2UserRequest userRequest) {
+		return super.loadUser(userRequest);
+	}
+
+	private OAuth2User handleExistingOAuthConnection(
+		UserOAuthConnectionEntity connection,
+		Map<String, Object> attributes
+	) {
+		UsersEntity user = usersRepository.findById(connection.getUserTsid())
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+		return new OAuthPrincipal(user, attributes);
+	}
+
+	private OAuth2User handleNewOAuthUser(
+		OAuthUserInfo oAuthUserInfo,
+		Map<String, Object> attributes
+	) {
+		UsersEntity newUser = userService.socialJoin(oAuthUserInfo);
+		UserOAuthConnectionEntity connection = UserOAuthConnectionEntity.from(
+			newUser.getTsid(),
+			oAuthUserInfo
+		);
+		oauthConnectionRepository.save(connection);
+		return new OAuthPrincipal(newUser, attributes);
 	}
 }
+

--- a/src/main/java/com/gathering/common/exception/ErrorCode.java
+++ b/src/main/java/com/gathering/common/exception/ErrorCode.java
@@ -45,7 +45,11 @@ public enum ErrorCode {
 	EMAIL_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 가입된 이메일입니다. 기존 계정으로 로그인 후 설정에서 소셜 계정을 연동해주세요."),
 
 	// OAuth 관련 에러
-	OAUTH_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 제공자입니다.");
+	OAUTH_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 제공자입니다."),
+	OAUTH_DIFFERENT_ACCOUNT(
+		HttpStatus.CONFLICT,
+		"해당 이메일로 가입된 다른 계정이 있습니다. 기존 계정으로 로그인 후 소셜 계정 연동을 진행해주세요."
+	);
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/gathering/user/domain/model/UserOAuthConnectionEntity.java
+++ b/src/main/java/com/gathering/user/domain/model/UserOAuthConnectionEntity.java
@@ -1,0 +1,140 @@
+package com.gathering.user.domain.model;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Objects;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.gathering.auth.domain.OAuthUserInfo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자 소셜 계정 연동 정보 엔티티
+ *
+ * 복합 PK: (user_tsid, provider)
+ */
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@IdClass(UserOAuthConnectionEntity.ConnectionId.class)
+@Table(
+	name = "user_oauth_connections",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_provider_user", columnNames = {"provider", "provider_id"})
+	},
+	indexes = {
+		@Index(name = "idx_user_tsid", columnList = "user_tsid")
+	}
+)
+public class UserOAuthConnectionEntity {
+
+	@Id
+	@Column(name = "user_tsid", nullable = false, length = 13, columnDefinition = "CHAR(13)")
+	private String userTsid;
+
+	@Id
+	@Column(nullable = false, length = 20)
+	@Enumerated(EnumType.STRING)
+	private OAuthProvider provider;
+
+	@Column(name = "provider_id", nullable = false)
+	private String providerId;
+
+	@Column(nullable = false, length = 320)
+	private String email;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	@CreatedDate
+	private Instant createdAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(
+		name = "user_tsid",
+		insertable = false,
+		updatable = false,
+		foreignKey = @ForeignKey(name = "fk_user_oauth_user_tsid")
+	)
+	private UsersEntity user;
+
+	/**
+	 * 소셜 연동 정보 생성 팩토리 메서드
+	 */
+	public static UserOAuthConnectionEntity of(
+		String userTsid,
+		OAuthProvider provider,
+		String providerId,
+		String email
+	) {
+		return UserOAuthConnectionEntity.builder()
+			.userTsid(userTsid)
+			.provider(provider)
+			.providerId(providerId)
+			.email(email)
+			.build();
+	}
+
+	/**
+	 * OAuthUserInfo로부터 연동 정보 생성
+	 */
+	public static UserOAuthConnectionEntity from(String userTsid, OAuthUserInfo oAuthUserInfo) {
+		return of(
+			userTsid,
+			oAuthUserInfo.getProvider(),
+			oAuthUserInfo.getProviderId(),
+			oAuthUserInfo.getEmail()
+		);
+	}
+
+	/**
+	 * 복합 PK 클래스
+	 */
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor
+	public static class ConnectionId implements Serializable {
+
+		private String userTsid;
+		private OAuthProvider provider;
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			ConnectionId that = (ConnectionId)o;
+			return Objects.equals(userTsid, that.userTsid) && provider == that.provider;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(userTsid, provider);
+		}
+	}
+}

--- a/src/main/java/com/gathering/user/domain/repository/UserOAuthConnectionRepository.java
+++ b/src/main/java/com/gathering/user/domain/repository/UserOAuthConnectionRepository.java
@@ -1,0 +1,27 @@
+package com.gathering.user.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.gathering.user.domain.model.OAuthProvider;
+import com.gathering.user.domain.model.UserOAuthConnectionEntity;
+
+@Repository
+public interface UserOAuthConnectionRepository extends
+	JpaRepository<UserOAuthConnectionEntity, UserOAuthConnectionEntity.ConnectionId> {
+
+	/**
+	 * 특정 OAuth 제공자와 provider ID로 연동 정보 조회
+	 */
+	Optional<UserOAuthConnectionEntity> findByProviderAndProviderId(
+		OAuthProvider provider,
+		String providerId
+	);
+
+	/**
+	 * 특정 사용자의 모든 소셜 연동 정보 삭제 (회원 탈퇴 시 사용)
+	 */
+	void deleteByUserTsid(String userTsid);
+}

--- a/src/test/java/com/gathering/auth/application/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/gathering/auth/application/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,216 @@
+package com.gathering.auth.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.gathering.auth.domain.OAuthPrincipal;
+import com.gathering.common.exception.BusinessException;
+import com.gathering.common.exception.ErrorCode;
+import com.gathering.user.application.UserService;
+import com.gathering.user.domain.model.OAuthProvider;
+import com.gathering.user.domain.model.UserOAuthConnectionEntity;
+import com.gathering.user.domain.model.UsersEntity;
+import com.gathering.user.domain.repository.UserOAuthConnectionRepository;
+import com.gathering.user.domain.repository.UsersRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CustomOAuth2UserService 테스트")
+class CustomOAuth2UserServiceTest {
+
+	@Spy
+	@InjectMocks
+	private CustomOAuth2UserService customOAuth2UserService;
+
+	@Mock
+	private UserService userService;
+
+	@Mock
+	private UsersRepository usersRepository;
+
+	@Mock
+	private UserOAuthConnectionRepository oauthConnectionRepository;
+
+	private OAuth2UserRequest userRequest;
+	private Map<String, Object> googleAttributes;
+
+	@BeforeEach
+	void setUp() {
+		// Google attributes 준비 (Google과의 통신 성공 가정)
+		googleAttributes = new HashMap<>();
+		googleAttributes.put("sub", "google-user-123");
+		googleAttributes.put("email", "test@gmail.com");
+		googleAttributes.put("name", "홍길동");
+		googleAttributes.put("picture", "https://example.com/profile.jpg");
+
+		// OAuth2UserRequest 생성
+		ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("google")
+			.clientId("test-client-id")
+			.clientSecret("test-client-secret")
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+			.scope("profile", "email")
+			.authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
+			.tokenUri("https://oauth2.googleapis.com/token")
+			.userInfoUri("https://openidconnect.googleapis.com/v1/userinfo")
+			.userNameAttributeName("email")
+			.clientName("Google")
+			.build();
+
+		OAuth2AccessToken accessToken = new OAuth2AccessToken(
+			OAuth2AccessToken.TokenType.BEARER,
+			"mock-access-token",
+			null,
+			null
+		);
+
+		userRequest = new OAuth2UserRequest(clientRegistration, accessToken);
+
+		// super.loadUser() Mock - Google과의 통신이 성공했다고 가정
+		OAuth2User mockOAuth2User = new DefaultOAuth2User(
+			java.util.Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+			googleAttributes,
+			"email"
+		);
+		doReturn(mockOAuth2User).when(customOAuth2UserService).callSuperLoadUser(any());
+	}
+
+	@Nested
+	@DisplayName("소셜 로그인 처리")
+	class SocialLoginHandling {
+
+		@Test
+		@DisplayName("기존_연동된_계정으로_로그인하면_해당_사용자의_OAuthPrincipal을_반환한다")
+		void 기존_연동된_계정으로_로그인하면_해당_사용자의_OAuthPrincipal을_반환한다() {
+			// given
+			String userTsid = "01HQXYZ123456";
+
+			UsersEntity existingUser = UsersEntity.builder()
+				.tsid(userTsid)
+				.email("test@gmail.com")
+				.name("홍길동")
+				.emailVerified(true)
+				.build();
+
+			UserOAuthConnectionEntity existingConnection = UserOAuthConnectionEntity.of(
+				userTsid,
+				OAuthProvider.GOOGLE,
+				"google-user-123",
+				"test@gmail.com"
+			);
+
+			when(oauthConnectionRepository.findByProviderAndProviderId(
+				OAuthProvider.GOOGLE,
+				"google-user-123"
+			)).thenReturn(Optional.of(existingConnection));
+
+			when(usersRepository.findById(userTsid)).thenReturn(Optional.of(existingUser));
+
+			// when
+			OAuth2User result = customOAuth2UserService.loadUser(userRequest);
+
+			// then
+			assertThat(result).isInstanceOf(OAuthPrincipal.class);
+			OAuthPrincipal principal = (OAuthPrincipal)result;
+			assertThat(principal.getName()).isEqualTo("test@gmail.com");
+			assertThat(principal.getUsername()).isEqualTo(userTsid);
+
+			verify(oauthConnectionRepository, times(1)).findByProviderAndProviderId(
+				OAuthProvider.GOOGLE,
+				"google-user-123"
+			);
+			verify(usersRepository, times(1)).findById(userTsid);
+			verify(usersRepository, never()).findByEmail(anyString());
+			verify(userService, never()).socialJoin(any());
+		}
+
+		@Test
+		@DisplayName("신규_사용자_회원가입_후_연동정보를_저장하고_OAuthPrincipal을_반환한다")
+		void 신규_사용자_회원가입_후_연동정보를_저장하고_OAuthPrincipal을_반환한다() {
+			// given
+			UsersEntity newUser = UsersEntity.builder()
+				.tsid("01HQXYZ999999")
+				.email("test@gmail.com")
+				.name("홍길동")
+				.emailVerified(true)
+				.build();
+
+			when(oauthConnectionRepository.findByProviderAndProviderId(
+				OAuthProvider.GOOGLE,
+				"google-user-123"
+			)).thenReturn(Optional.empty());
+
+			when(usersRepository.findByEmail("test@gmail.com")).thenReturn(Optional.empty());
+			when(userService.socialJoin(any())).thenReturn(newUser);
+
+			// when
+			OAuth2User result = customOAuth2UserService.loadUser(userRequest);
+
+			// then
+			assertThat(result).isInstanceOf(OAuthPrincipal.class);
+			OAuthPrincipal principal = (OAuthPrincipal)result;
+			assertThat(principal.getName()).isEqualTo("test@gmail.com");
+			assertThat(principal.getUsername()).isEqualTo("01HQXYZ999999");
+
+			verify(oauthConnectionRepository, times(1)).findByProviderAndProviderId(
+				OAuthProvider.GOOGLE,
+				"google-user-123"
+			);
+			verify(usersRepository, times(1)).findByEmail("test@gmail.com");
+			verify(userService, times(1)).socialJoin(any());
+			verify(oauthConnectionRepository, times(1)).save(any(UserOAuthConnectionEntity.class));
+		}
+
+		@Test
+		@DisplayName("이메일_중복_다른_계정이_있으면_OAUTH_DIFFERENT_ACCOUNT_예외가_발생한다")
+		void 이메일_중복_다른_계정이_있으면_OAUTH_DIFFERENT_ACCOUNT_예외가_발생한다() {
+			// given
+			UsersEntity existingUser = UsersEntity.builder()
+				.tsid("01HQXYZ123456")
+				.email("test@gmail.com")
+				.name("기존사용자")
+				.emailVerified(false) // 일반 회원가입 사용자
+				.build();
+
+			when(oauthConnectionRepository.findByProviderAndProviderId(
+				OAuthProvider.GOOGLE,
+				"google-user-123"
+			)).thenReturn(Optional.empty());
+
+			when(usersRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(existingUser));
+
+			// when & then
+			assertThatThrownBy(() -> customOAuth2UserService.loadUser(userRequest))
+				.isInstanceOf(BusinessException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.OAUTH_DIFFERENT_ACCOUNT);
+
+			verify(oauthConnectionRepository, times(1)).findByProviderAndProviderId(
+				OAuthProvider.GOOGLE,
+				"google-user-123"
+			);
+			verify(usersRepository, times(1)).findByEmail("test@gmail.com");
+			verify(userService, never()).socialJoin(any());
+			verify(oauthConnectionRepository, never()).save(any());
+		}
+	}
+}

--- a/src/test/java/com/gathering/user/UserServiceTest.java
+++ b/src/test/java/com/gathering/user/UserServiceTest.java
@@ -20,6 +20,7 @@ import com.gathering.user.application.UserService;
 import com.gathering.user.application.UserValidator;
 import com.gathering.user.domain.model.UserSecurityEntity;
 import com.gathering.user.domain.model.UsersEntity;
+import com.gathering.user.domain.repository.UserOAuthConnectionRepository;
 import com.gathering.user.domain.repository.UserSecurityRepository;
 import com.gathering.user.domain.repository.UsersRepository;
 import com.gathering.user.presentation.dto.WithdrawRequest;
@@ -38,6 +39,9 @@ class UserServiceTest {
 
 	@Mock
 	private UserSecurityRepository userSecurityRepository;
+
+	@Mock
+	private UserOAuthConnectionRepository oauthConnectionRepository;
 
 	@Mock
 	private PasswordEncoder passwordEncoder;
@@ -77,8 +81,11 @@ class UserServiceTest {
 		verify(usersRepository, times(1)).findById(tsid);
 		verify(userSecurityRepository, times(1)).findById(tsid);
 		verify(passwordEncoder, times(1)).matches(password, encodedPassword);
+		// user entitiy 가 삭제 되면서 함께 사라져야하는 데이터가 잘 삭제되는가?
+		verify(oauthConnectionRepository, times(1)).deleteByUserTsid(tsid);
 		verify(userSecurityRepository, times(1)).deleteById(tsid);
 		verify(usersRepository, times(1)).deleteById(tsid);
+		// users 삭제 이후 세션에 대한 부분도 삭제되는가?
 		verify(refreshTokenService, times(1)).deleteAllRefreshTokensByTsid(tsid);
 	}
 
@@ -108,7 +115,6 @@ class UserServiceTest {
 	void withdrawInvalidPassword() {
 		// given
 		String tsid = "1234567890123";
-		String correctPassword = "Password1!";
 		String wrongPassword = "WrongPass1!";
 		String encodedPassword = "$2a$10$encoded_password";
 
@@ -164,6 +170,7 @@ class UserServiceTest {
 		verify(usersRepository, times(1)).findById(tsid);
 		verify(userSecurityRepository, times(1)).findById(tsid);
 		verify(passwordEncoder, never()).matches(anyString(), anyString());
+		verify(oauthConnectionRepository, times(1)).deleteByUserTsid(tsid);
 		verify(userSecurityRepository, times(1)).deleteById(tsid);
 		verify(usersRepository, times(1)).deleteById(tsid);
 		verify(refreshTokenService, times(1)).deleteAllRefreshTokensByTsid(tsid);

--- a/src/test/java/com/gathering/user/domain/model/UserOAuthConnectionEntityTest.java
+++ b/src/test/java/com/gathering/user/domain/model/UserOAuthConnectionEntityTest.java
@@ -1,0 +1,115 @@
+package com.gathering.user.domain.model;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.gathering.auth.domain.OAuthUserInfo;
+
+@DisplayName("UserOAuthConnectionEntity 도메인 테스트")
+class UserOAuthConnectionEntityTest {
+
+	@Nested
+	@DisplayName("복합 PK 동등성 테스트")
+	class CompositePrimaryKeyEquality {
+
+		@Test
+		@DisplayName("같은_userTsid와_provider를_가진_ID는_동등하다")
+		void 같은_userTsid와_provider를_가진_ID는_동등하다() {
+			// given
+			UserOAuthConnectionEntity.ConnectionId id1 =
+				new UserOAuthConnectionEntity.ConnectionId("01HQXYZ123456", OAuthProvider.GOOGLE);
+			UserOAuthConnectionEntity.ConnectionId id2 =
+				new UserOAuthConnectionEntity.ConnectionId("01HQXYZ123456", OAuthProvider.GOOGLE);
+
+			// when & then
+			assertThat(id1).isEqualTo(id2);
+			assertThat(id1.hashCode()).isEqualTo(id2.hashCode());
+		}
+
+		@Test
+		@DisplayName("다른_userTsid를_가진_ID는_동등하지_않다")
+		void 다른_userTsid를_가진_ID는_동등하지_않다() {
+			// given
+			UserOAuthConnectionEntity.ConnectionId id1 =
+				new UserOAuthConnectionEntity.ConnectionId("01HQXYZ123456", OAuthProvider.GOOGLE);
+			UserOAuthConnectionEntity.ConnectionId id2 =
+				new UserOAuthConnectionEntity.ConnectionId("01HQXYZ999999", OAuthProvider.GOOGLE);
+
+			// when & then
+			assertThat(id1).isNotEqualTo(id2);
+		}
+
+		@Test
+		@DisplayName("다른_provider를_가진_ID는_동등하지_않다")
+		void 다른_provider를_가진_ID는_동등하지_않다() {
+			// given
+			UserOAuthConnectionEntity.ConnectionId id1 =
+				new UserOAuthConnectionEntity.ConnectionId("01HQXYZ123456", OAuthProvider.GOOGLE);
+			UserOAuthConnectionEntity.ConnectionId id2 =
+				new UserOAuthConnectionEntity.ConnectionId("01HQXYZ123456", OAuthProvider.GOOGLE); // 같은 provider
+
+			// when & then
+			assertThat(id1).isEqualTo(id2); // 같은 provider이므로 동등
+		}
+	}
+
+	@Nested
+	@DisplayName("팩토리 메서드 테스트")
+	class FactoryMethodTest {
+
+		@Test
+		@DisplayName("of_메서드로_UserOAuthConnectionEntity를_생성한다")
+		void of_메서드로_UserOAuthConnectionEntity를_생성한다() {
+			// given
+			String userTsid = "01HQXYZ123456";
+			OAuthProvider provider = OAuthProvider.GOOGLE;
+			String providerId = "google-user-123";
+			String email = "test@gmail.com";
+
+			// when
+			UserOAuthConnectionEntity connection = UserOAuthConnectionEntity.of(
+				userTsid,
+				provider,
+				providerId,
+				email
+			);
+
+			// then
+			assertThat(connection).isNotNull();
+			assertThat(connection.getUserTsid()).isEqualTo(userTsid);
+			assertThat(connection.getProvider()).isEqualTo(provider);
+			assertThat(connection.getProviderId()).isEqualTo(providerId);
+			assertThat(connection.getEmail()).isEqualTo(email);
+		}
+
+		@Test
+		@DisplayName("from_메서드로_OAuthUserInfo로부터_UserOAuthConnectionEntity를_생성한다")
+		void from_메서드로_OAuthUserInfo로부터_UserOAuthConnectionEntity를_생성한다() {
+			// given
+			String userTsid = "01HQXYZ123456";
+			OAuthUserInfo oAuthUserInfo = OAuthUserInfo.builder()
+				.provider(OAuthProvider.GOOGLE)
+				.providerId("google-user-123")
+				.email("test@gmail.com")
+				.name("홍길동")
+				.profileImageUrl("https://example.com/profile.jpg")
+				.build();
+
+			// when
+			UserOAuthConnectionEntity connection = UserOAuthConnectionEntity.from(
+				userTsid,
+				oAuthUserInfo
+			);
+
+			// then
+			assertThat(connection).isNotNull();
+			assertThat(connection.getUserTsid()).isEqualTo(userTsid);
+			assertThat(connection.getProvider()).isEqualTo(OAuthProvider.GOOGLE);
+			assertThat(connection.getProviderId()).isEqualTo("google-user-123");
+			assertThat(connection.getEmail()).isEqualTo("test@gmail.com");
+		}
+	}
+}


### PR DESCRIPTION
# 📝 Pull Request

## 🎯 요약 (Summary)

구글 소셜 로그인 후 재로그인이 불가능한 문제를 해결하기 위해 OAuth 연동 정보를 DB에 저장하고, 소셜 로그인 시 분기 처리 로직을 구현했습니다.

* **무엇을 변경했고**: OAuth 연동 정보를 저장하는 `user_oauth_connections` 테이블을 추가하고, 소셜 로그인 시 기존 연동/신규 가입/이메일 충돌 3가지 시나리오를 분기 처리
* **왜 이 변경이 필요한지**: 기존에는 소셜 회원가입 후 재로그인 시 "이미 가입된 이메일" 에러가 발생하여 로그인이 불가능했음. OAuth 연동 정보를 저장하여 이미 가입된 소셜 계정을 식별하고 로그인 처리

Resolves #38

---

## 💡 유즈 케이스 (Use Case)

**다루는 유즈케이스**

1. **소셜 로그인 - 기존 연동 계정**: provider + providerId로 기존 연동 확인 후 로그인
2. **소셜 로그인 - 신규 사용자**: 회원가입 + 연동 정보 저장 + 로그인
3. **소셜 로그인 - 이메일 충돌**: 이메일로 가입된 다른 계정이 있으면 에러 메시지
4. **회원 탈퇴 - 소셜 사용자**: 비밀번호 없이 탈퇴 가능
5. **회원 탈퇴 - 일반 사용자**: 비밀번호 검증 후 탈퇴

**작성된 테스트 케이스**

* `CustomOAuth2UserServiceTest` (소셜 로그인 분기 처리)
  ```
  use case: 소셜 로그인
  성공:
    - 기존 연동된 계정으로 로그인 성공
    - 신규 사용자 회원가입 및 연동 정보 저장 성공
  실패:
    - 이메일로 가입된 다른 계정이 있으면 OAUTH_DIFFERENT_ACCOUNT 에러
  ```

* `UserOAuthConnectionEntityTest` (도메인 모델)
  ```
  use case: OAuth 연동 정보 생성
  성공:
    - 복합 PK (userTsid + provider) 동등성 검증
    - OAuthUserInfo로부터 Entity 생성 (팩토리 메서드)
  ```

* `UserServiceTest` (회원 탈퇴)
  ```
  use case: 회원 탈퇴
  성공:
    - 일반 사용자 비밀번호 검증 후 탈퇴
    - 소셜 사용자 비밀번호 없이 탈퇴
  실패:
    - 일반 사용자가 비밀번호 없이 탈퇴 시도하면 INVALID_CURRENT_PASSWORD 에러
  ```

---

## 🧱 변경 사항 및 변경 맥락 (Changes & Rationale)

### 1. OAuth 연동 정보 저장

**AS_IS**: 소셜 로그인 시 연동 정보를 DB에 저장하지 않아, 재로그인 시 이메일 중복 에러 발생

**TO_BE**: `user_oauth_connections` 테이블에 provider + providerId를 저장하여 기존 연동 확인

**REASON**: 소셜 계정으로 가입한 사용자가 재로그인할 수 있도록 하기 위함

**변경 파일**:
- `UserOAuthConnectionEntity.java` (신규): 복합 PK (user_tsid + provider) 사용
- `UserOAuthConnectionRepository.java` (신규): `findByProviderAndProviderId()`, `deleteByUserTsid()` 메서드

### 2. 소셜 로그인 분기 처리

**AS_IS**: 이메일 중복 시 무조건 `EMAIL_ALREADY_REGISTERED` 에러 반환

**TO_BE**: 3가지 시나리오 분기 처리
1. 기존 연동 → 로그인
2. 신규 사용자 → 회원가입 + 연동 저장
3. 이메일 충돌 → `OAUTH_DIFFERENT_ACCOUNT` 에러 (연동 안내)

**REASON**: 소셜 로그인 사용자와 일반 회원가입 사용자를 구분하여 적절한 처리 제공

**변경 파일**:
- `CustomOAuth2UserService.java`: 분기 처리 로직 구현
- `ErrorCode.java`: `OAUTH_DIFFERENT_ACCOUNT` 에러 코드 추가

### 3. 소셜 사용자 탈퇴 지원

**AS_IS**: 모든 사용자가 탈퇴 시 비밀번호 필수

**TO_BE**: 소셜 사용자는 `password_hash`가 null이므로 비밀번호 검증 생략

**REASON**: 소셜 로그인 사용자는 비밀번호가 없으므로 검증 불가

**변경 파일**:
- `UserService.java`: 비밀번호 검증 조건 수정, OAuth 연동 정보 명시적 삭제

---

## ✅ 체크리스트 (Checklist)

- [x] 테스트가 모두 통과한다 (89 tests completed)
- [x] 빌드가 성공한다
- [x] 불필요한 변수, 메서드, import 가 제거되었다
- [x] checkstyle, formatter 등 코드 규칙을 정확히 준수했다

---

## 📎 기타 참고 사항

### 설계 결정

1. **복합 PK 선택**: `@IdClass` 패턴 사용
   - 한 사용자가 동일 제공자로 중복 연동 방지
   - `uk_provider_user` 제약조건으로 동일 소셜 계정의 여러 사용자 연동 방지

2. **CASCADE DELETE 미사용**: 명시적 삭제 처리
   - JPA에서 명시적으로 `deleteByUserTsid()` 호출
   - 삭제 순서: OAuth 연동 → user_security → users → Redis tokens

3. **테스트 전략**: TDD (Red → Green → Refactor)
   - 도메인 테스트 → Repository 메서드 → Service 테스트 순으로 구현
   - `@Spy`를 사용하여 Google 통신을 모킹 (`callSuperLoadUser()` 메서드 분리)

### 트레이드오프

- **last_login_at 컬럼 제거**: 로그인 이력은 별도 테이블에서 관리하는 것이 적합하다고 판단
- **불필요한 인덱스 제거**: provider + providerId 조회는 유니크 제약조건만으로 충분

### 향후 개선 사항

- 사용자가 기존 계정에 소셜 계정을 연동하는 API 추가 고려
- 한 사용자가 여러 소셜 제공자 (Google, Kakao 등)를 연동할 수 있도록 확장 가능