### PR TITLE
feat: 파일 업로드 기능 구현 (프로필/모임 이미지)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'com.h2database:h2'
 
+    // Apache Tika - MIME 타입 검사
+    implementation 'org.apache.tika:tika-core:2.9.2'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/gathering/auth/infra/SecurityConfig.java
+++ b/src/main/java/com/gathering/auth/infra/SecurityConfig.java
@@ -26,7 +26,9 @@ public class SecurityConfig {
 		// OAuth 엔드포인트 (인증 불필요)
 		"/oauth/**", "/login/oauth2/**",
 		// API 문서
-		"/docs/**", "/redoc.html", "/my-info"
+		"/docs/**", "/redoc.html", "/my-info",
+		// 업로드된 파일 (개발 환경 정적 리소스 서빙)
+		"/uploads/**"
 	};
 
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;

--- a/src/main/java/com/gathering/common/exception/ErrorCode.java
+++ b/src/main/java/com/gathering/common/exception/ErrorCode.java
@@ -55,7 +55,18 @@ public enum ErrorCode {
 	CANNOT_UNLINK_LAST_LOGIN_METHOD(
 		HttpStatus.BAD_REQUEST,
 		"마지막 로그인 수단입니다. 비밀번호를 설정하거나 다른 소셜 계정을 연동한 후 해제할 수 있습니다."
-	);
+	),
+
+	// 모임 관련 에러
+	GATHERING_NOT_FOUND(HttpStatus.NOT_FOUND, "모임을 찾을 수 없습니다."),
+	GATHERING_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 모임에 대한 권한이 없습니다."),
+
+	// 파일 업로드 관련 에러 (400 Bad Request)
+	FILE_EMPTY(HttpStatus.BAD_REQUEST, "업로드할 파일이 없습니다."),
+	FILE_EXTENSION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 확장자입니다."),
+	FILE_MIME_TYPE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 형식입니다."),
+	FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 허용 범위를 초과했습니다."),
+	FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/gathering/common/exception/ErrorCode.java
+++ b/src/main/java/com/gathering/common/exception/ErrorCode.java
@@ -66,7 +66,8 @@ public enum ErrorCode {
 	FILE_EXTENSION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 확장자입니다."),
 	FILE_MIME_TYPE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 형식입니다."),
 	FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 허용 범위를 초과했습니다."),
-	FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
+	FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
+	FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/gathering/file/application/FileUploadService.java
+++ b/src/main/java/com/gathering/file/application/FileUploadService.java
@@ -1,5 +1,7 @@
 package com.gathering.file.application;
 
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -62,6 +64,41 @@ public class FileUploadService {
 
 		log.info("파일 업로드 완료 - uploaderTsid={}, storagePath={}, publicUrl={}", uploaderTsid, storageResult.storagePath(), storageResult.publicUrl());
 		return storageResult.publicUrl();
+	}
+
+	public List<FileMetadataEntity> findFilesByUploaderAndType(String uploaderTsid, FileType fileType) {
+		return fileMetadataRepository.findByUploaderTsidAndFileType(uploaderTsid, fileType);
+	}
+
+	/**
+	 * DB 메타데이터 삭제 + 커밋 이후 스토리지 파일 삭제
+	 * 커밋 이후 삭제하는 이유: 트랜잭션 롤백 시 기존 파일 보존
+	 */
+	@Transactional
+	public void deleteFilesWithCleanup(List<FileMetadataEntity> metadataList) {
+		fileMetadataRepository.deleteAll(metadataList);
+		List<String> storagePaths = metadataList.stream()
+			.map(FileMetadataEntity::getStoragePath)
+			.toList();
+		registerStorageDeleteAfterCommit(storagePaths);
+	}
+
+	private void registerStorageDeleteAfterCommit(List<String> storagePaths) {
+		if (storagePaths.isEmpty() || !TransactionSynchronizationManager.isSynchronizationActive()) {
+			return;
+		}
+		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+			@Override
+			public void afterCommit() {
+				storagePaths.forEach(path -> {
+					try {
+						storageService.delete(path);
+					} catch (Exception e) {
+						log.error("파일 삭제 실패 - storagePath={}, 수동 삭제 필요", path, e);
+					}
+				});
+			}
+		});
 	}
 
 	private void registerRollbackCleanup(String storagePath) {

--- a/src/main/java/com/gathering/file/application/FileUploadService.java
+++ b/src/main/java/com/gathering/file/application/FileUploadService.java
@@ -1,5 +1,7 @@
 package com.gathering.file.application;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -15,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class FileUploadService {
+
+	private static final Logger log = LoggerFactory.getLogger(FileUploadService.class);
 
 	private final FileValidator fileValidator;
 	private final StorageService storageService;
@@ -34,6 +38,8 @@ public class FileUploadService {
 	 */
 	@Transactional
 	public String upload(MultipartFile file, FileType fileType, String uploaderTsid) {
+		log.info("파일 업로드 시작 - uploaderTsid={}, fileType={}, filename={}, size={}bytes", uploaderTsid, fileType, file.getOriginalFilename(), file.getSize());
+
 		fileValidator.validate(file, fileType);
 
 		String directory = resolveDirectory(fileType);
@@ -54,6 +60,7 @@ public class FileUploadService {
 
 		fileMetadataRepository.save(metadata);
 
+		log.info("파일 업로드 완료 - uploaderTsid={}, storagePath={}, publicUrl={}", uploaderTsid, storageResult.storagePath(), storageResult.publicUrl());
 		return storageResult.publicUrl();
 	}
 
@@ -63,6 +70,7 @@ public class FileUploadService {
 				@Override
 				public void afterCompletion(int status) {
 					if (status == STATUS_ROLLED_BACK) {
+						log.warn("트랜잭션 롤백으로 인한 파일 삭제 - storagePath={}", storagePath);
 						storageService.delete(storagePath);
 					}
 				}

--- a/src/main/java/com/gathering/file/application/FileUploadService.java
+++ b/src/main/java/com/gathering/file/application/FileUploadService.java
@@ -1,0 +1,79 @@
+package com.gathering.file.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.gathering.file.domain.model.FileMetadataEntity;
+import com.gathering.file.domain.model.FileType;
+import com.gathering.file.domain.repository.FileMetadataRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FileUploadService {
+
+	private final FileValidator fileValidator;
+	private final StorageService storageService;
+	private final FileMetadataRepository fileMetadataRepository;
+
+	/**
+	 * 파일 업로드 처리
+	 * 1. 파일 유효성 검사
+	 * 2. 저장소에 파일 저장
+	 * 3. 트랜잭션 롤백 시 파일 삭제 콜백 등록
+	 * 4. 메타데이터 DB 저장
+	 *
+	 * @param file 업로드할 파일
+	 * @param fileType 파일 타입 (크기 제한 기준)
+	 * @param uploaderTsid 업로더 사용자 TSID
+	 * @return 업로드된 파일의 공개 URL
+	 */
+	@Transactional
+	public String upload(MultipartFile file, FileType fileType, String uploaderTsid) {
+		fileValidator.validate(file, fileType);
+
+		String directory = resolveDirectory(fileType);
+		StorageResult storageResult = storageService.store(file, directory);
+
+		// 트랜잭션 롤백 시 저장된 파일 삭제
+		registerRollbackCleanup(storageResult.storagePath());
+
+		FileMetadataEntity metadata = FileMetadataEntity.builder()
+			.originalFilename(file.getOriginalFilename())
+			.storedFilename(storageResult.storedFilename())
+			.storagePath(storageResult.storagePath())
+			.mimeType(file.getContentType())
+			.fileSize(file.getSize())
+			.uploaderTsid(uploaderTsid)
+			.fileType(fileType)
+			.build();
+
+		fileMetadataRepository.save(metadata);
+
+		return storageResult.publicUrl();
+	}
+
+	private void registerRollbackCleanup(String storagePath) {
+		if (TransactionSynchronizationManager.isSynchronizationActive()) {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCompletion(int status) {
+					if (status == STATUS_ROLLED_BACK) {
+						storageService.delete(storagePath);
+					}
+				}
+			});
+		}
+	}
+
+	private String resolveDirectory(FileType fileType) {
+		return switch (fileType) {
+			case PROFILE_IMAGE -> "profile-images";
+			case GATHERING_IMAGE -> "gathering-images";
+		};
+	}
+}

--- a/src/main/java/com/gathering/file/application/FileUploadService.java
+++ b/src/main/java/com/gathering/file/application/FileUploadService.java
@@ -13,7 +13,7 @@ import com.gathering.file.domain.model.FileMetadataEntity;
 import com.gathering.file.domain.model.FileType;
 import com.gathering.file.domain.repository.FileMetadataRepository;
 
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -42,7 +42,7 @@ public class FileUploadService {
 	public String upload(MultipartFile file, FileType fileType, String uploaderTsid) {
 		log.info("파일 업로드 시작 - uploaderTsid={}, fileType={}, filename={}, size={}bytes", uploaderTsid, fileType, file.getOriginalFilename(), file.getSize());
 
-		fileValidator.validate(file, fileType);
+		String detectedMimeType = fileValidator.validate(file, fileType);
 
 		String directory = resolveDirectory(fileType);
 		StorageResult storageResult = storageService.store(file, directory);
@@ -54,7 +54,7 @@ public class FileUploadService {
 			.originalFilename(file.getOriginalFilename())
 			.storedFilename(storageResult.storedFilename())
 			.storagePath(storageResult.storagePath())
-			.mimeType(file.getContentType())
+			.mimeType(detectedMimeType)
 			.fileSize(file.getSize())
 			.uploaderTsid(uploaderTsid)
 			.fileType(fileType)

--- a/src/main/java/com/gathering/file/application/FileUploadService.java
+++ b/src/main/java/com/gathering/file/application/FileUploadService.java
@@ -70,8 +70,13 @@ public class FileUploadService {
 				@Override
 				public void afterCompletion(int status) {
 					if (status == STATUS_ROLLED_BACK) {
-						log.warn("트랜잭션 롤백으로 인한 파일 삭제 - storagePath={}", storagePath);
-						storageService.delete(storagePath);
+						log.warn("트랜잭션 롤백으로 인한 파일 삭제 시도 - storagePath={}", storagePath);
+						try {
+							storageService.delete(storagePath);
+						} catch (Exception e) {
+							// afterCompletion 내부 예외는 Spring이 삼키므로 명시적으로 로그 기록
+							log.error("롤백 후 파일 삭제 실패 - storagePath={}, 수동 삭제 필요", storagePath, e);
+						}
 					}
 				}
 			});

--- a/src/main/java/com/gathering/file/application/FileValidator.java
+++ b/src/main/java/com/gathering/file/application/FileValidator.java
@@ -25,8 +25,8 @@ public class FileValidator {
 
 	private static final Detector DETECTOR = new DefaultDetector();
 
-	private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp");
-	private static final Set<String> ALLOWED_MIME_TYPES = Set.of("image/jpeg", "image/png", "image/gif", "image/webp");
+	public static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp");
+	public static final Set<String> ALLOWED_MIME_TYPES = Set.of("image/jpeg", "image/png", "image/gif", "image/webp");
 
 	public void validate(MultipartFile file, FileType fileType) {
 		validateNotEmpty(file);
@@ -35,14 +35,14 @@ public class FileValidator {
 		validateSize(file, fileType);
 	}
 
-	private void validateNotEmpty(MultipartFile file) {
+	public void validateNotEmpty(MultipartFile file) {
 		if (file == null || file.isEmpty()) {
 			log.warn("파일 검증 실패: 파일이 비어있음");
 			throw new BusinessException(ErrorCode.FILE_EMPTY);
 		}
 	}
 
-	private void validateExtension(String filename) {
+	public void validateExtension(String filename) {
 		if (filename == null || !filename.contains(".")) {
 			log.warn("파일 검증 실패: 확장자 없음 - filename={}", filename);
 			throw new BusinessException(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
@@ -54,7 +54,7 @@ public class FileValidator {
 		}
 	}
 
-	private void validateMimeType(MultipartFile file) {
+	public void validateMimeType(MultipartFile file) {
 		if (file == null) {
 			log.warn("파일 검증 실패: 파일이 null");
 			throw new BusinessException(ErrorCode.FILE_EMPTY);
@@ -77,7 +77,7 @@ public class FileValidator {
 		}
 	}
 
-	private void validateSize(MultipartFile file, FileType fileType) {
+	public void validateSize(MultipartFile file, FileType fileType) {
 		if (file == null) {
 			log.warn("파일 검증 실패: 파일이 null");
 			throw new BusinessException(ErrorCode.FILE_EMPTY);

--- a/src/main/java/com/gathering/file/application/FileValidator.java
+++ b/src/main/java/com/gathering/file/application/FileValidator.java
@@ -55,6 +55,10 @@ public class FileValidator {
 	}
 
 	private void validateMimeType(MultipartFile file) {
+		if (file == null) {
+			log.warn("파일 검증 실패: 파일이 null");
+			throw new BusinessException(ErrorCode.FILE_EMPTY);
+		}
 		String detectedMimeType = detectMimeType(file);
 		if (!ALLOWED_MIME_TYPES.contains(detectedMimeType)) {
 			log.warn("파일 검증 실패: 허용되지 않는 MIME 타입 - filename={}, detectedMimeType={}, allowed={}", file.getOriginalFilename(), detectedMimeType, ALLOWED_MIME_TYPES);
@@ -74,6 +78,14 @@ public class FileValidator {
 	}
 
 	private void validateSize(MultipartFile file, FileType fileType) {
+		if (file == null) {
+			log.warn("파일 검증 실패: 파일이 null");
+			throw new BusinessException(ErrorCode.FILE_EMPTY);
+		}
+		if (fileType == null) {
+			log.warn("파일 검증 실패: fileType이 null - filename={}", file.getOriginalFilename());
+			throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+		}
 		if (file.getSize() > fileType.getMaxSize()) {
 			log.warn("파일 검증 실패: 파일 크기 초과 - filename={}, size={}bytes, maxSize={}bytes, fileType={}", file.getOriginalFilename(), file.getSize(), fileType.getMaxSize(), fileType);
 			throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED);

--- a/src/main/java/com/gathering/file/application/FileValidator.java
+++ b/src/main/java/com/gathering/file/application/FileValidator.java
@@ -86,7 +86,7 @@ public class FileValidator {
 			log.warn("파일 검증 실패: fileType이 null - filename={}", file.getOriginalFilename());
 			throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
 		}
-		if (file.getSize() > fileType.getMaxSize()) {
+		if (fileType.getMaxSize() > 0 && file.getSize() > fileType.getMaxSize()) {
 			log.warn("파일 검증 실패: 파일 크기 초과 - filename={}, size={}bytes, maxSize={}bytes, fileType={}", file.getOriginalFilename(), file.getSize(), fileType.getMaxSize(), fileType);
 			throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED);
 		}

--- a/src/main/java/com/gathering/file/application/FileValidator.java
+++ b/src/main/java/com/gathering/file/application/FileValidator.java
@@ -2,6 +2,7 @@ package com.gathering.file.application;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Set;
 
 import org.apache.tika.detect.DefaultDetector;
 import org.apache.tika.detect.Detector;
@@ -13,17 +14,14 @@ import org.springframework.web.multipart.MultipartFile;
 import com.gathering.common.exception.BusinessException;
 import com.gathering.common.exception.ErrorCode;
 import com.gathering.file.domain.model.FileType;
-import com.gathering.file.infra.FileUploadConfig;
-
-import lombok.RequiredArgsConstructor;
 
 @Component
-@RequiredArgsConstructor
 public class FileValidator {
 
 	private static final Detector DETECTOR = new DefaultDetector();
 
-	private final FileUploadConfig config;
+	private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp");
+	private static final Set<String> ALLOWED_MIME_TYPES = Set.of("image/jpeg", "image/png", "image/gif", "image/webp");
 
 	public void validate(MultipartFile file, FileType fileType) {
 		validateNotEmpty(file);
@@ -43,14 +41,14 @@ public class FileValidator {
 			throw new BusinessException(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
 		}
 		String extension = filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
-		if (!config.getAllowedExtensions().contains(extension)) {
+		if (!ALLOWED_EXTENSIONS.contains(extension)) {
 			throw new BusinessException(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
 		}
 	}
 
 	private void validateMimeType(MultipartFile file) {
 		String detectedMimeType = detectMimeType(file);
-		if (!config.getAllowedMimeTypes().contains(detectedMimeType)) {
+		if (!ALLOWED_MIME_TYPES.contains(detectedMimeType)) {
 			throw new BusinessException(ErrorCode.FILE_MIME_TYPE_NOT_ALLOWED);
 		}
 	}
@@ -66,16 +64,8 @@ public class FileValidator {
 	}
 
 	private void validateSize(MultipartFile file, FileType fileType) {
-		long maxSize = getMaxSize(fileType);
-		if (file.getSize() > maxSize) {
+		if (file.getSize() > fileType.getMaxSize()) {
 			throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED);
 		}
-	}
-
-	private long getMaxSize(FileType fileType) {
-		return switch (fileType) {
-			case PROFILE_IMAGE -> config.getMaxProfileImageSize();
-			case GATHERING_IMAGE -> config.getMaxGatheringImageSize();
-		};
 	}
 }

--- a/src/main/java/com/gathering/file/application/FileValidator.java
+++ b/src/main/java/com/gathering/file/application/FileValidator.java
@@ -1,5 +1,6 @@
 package com.gathering.file.application;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
@@ -8,6 +9,8 @@ import org.apache.tika.detect.DefaultDetector;
 import org.apache.tika.detect.Detector;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,6 +20,8 @@ import com.gathering.file.domain.model.FileType;
 
 @Component
 public class FileValidator {
+
+	private static final Logger log = LoggerFactory.getLogger(FileValidator.class);
 
 	private static final Detector DETECTOR = new DefaultDetector();
 
@@ -32,16 +37,19 @@ public class FileValidator {
 
 	private void validateNotEmpty(MultipartFile file) {
 		if (file == null || file.isEmpty()) {
+			log.warn("파일 검증 실패: 파일이 비어있음");
 			throw new BusinessException(ErrorCode.FILE_EMPTY);
 		}
 	}
 
 	private void validateExtension(String filename) {
 		if (filename == null || !filename.contains(".")) {
+			log.warn("파일 검증 실패: 확장자 없음 - filename={}", filename);
 			throw new BusinessException(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
 		}
 		String extension = filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
 		if (!ALLOWED_EXTENSIONS.contains(extension)) {
+			log.warn("파일 검증 실패: 허용되지 않는 확장자 - filename={}, extension={}, allowed={}", filename, extension, ALLOWED_EXTENSIONS);
 			throw new BusinessException(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
 		}
 	}
@@ -49,22 +57,25 @@ public class FileValidator {
 	private void validateMimeType(MultipartFile file) {
 		String detectedMimeType = detectMimeType(file);
 		if (!ALLOWED_MIME_TYPES.contains(detectedMimeType)) {
+			log.warn("파일 검증 실패: 허용되지 않는 MIME 타입 - filename={}, detectedMimeType={}, allowed={}", file.getOriginalFilename(), detectedMimeType, ALLOWED_MIME_TYPES);
 			throw new BusinessException(ErrorCode.FILE_MIME_TYPE_NOT_ALLOWED);
 		}
 	}
 
 	private String detectMimeType(MultipartFile file) {
-		try (InputStream inputStream = file.getInputStream()) {
+		try (InputStream inputStream = new BufferedInputStream(file.getInputStream())) {
 			Metadata metadata = new Metadata();
 			MediaType mediaType = DETECTOR.detect(inputStream, metadata);
 			return mediaType.toString();
 		} catch (IOException e) {
+			log.error("MIME 타입 감지 실패 - filename={}", file.getOriginalFilename(), e);
 			throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
 		}
 	}
 
 	private void validateSize(MultipartFile file, FileType fileType) {
 		if (file.getSize() > fileType.getMaxSize()) {
+			log.warn("파일 검증 실패: 파일 크기 초과 - filename={}, size={}bytes, maxSize={}bytes, fileType={}", file.getOriginalFilename(), file.getSize(), fileType.getMaxSize(), fileType);
 			throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED);
 		}
 	}

--- a/src/main/java/com/gathering/file/application/FileValidator.java
+++ b/src/main/java/com/gathering/file/application/FileValidator.java
@@ -1,0 +1,81 @@
+package com.gathering.file.application;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.tika.detect.DefaultDetector;
+import org.apache.tika.detect.Detector;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.mime.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.gathering.common.exception.BusinessException;
+import com.gathering.common.exception.ErrorCode;
+import com.gathering.file.domain.model.FileType;
+import com.gathering.file.infra.FileUploadConfig;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FileValidator {
+
+	private static final Detector DETECTOR = new DefaultDetector();
+
+	private final FileUploadConfig config;
+
+	public void validate(MultipartFile file, FileType fileType) {
+		validateNotEmpty(file);
+		validateExtension(file.getOriginalFilename());
+		validateMimeType(file);
+		validateSize(file, fileType);
+	}
+
+	private void validateNotEmpty(MultipartFile file) {
+		if (file == null || file.isEmpty()) {
+			throw new BusinessException(ErrorCode.FILE_EMPTY);
+		}
+	}
+
+	private void validateExtension(String filename) {
+		if (filename == null || !filename.contains(".")) {
+			throw new BusinessException(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
+		}
+		String extension = filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
+		if (!config.getAllowedExtensions().contains(extension)) {
+			throw new BusinessException(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
+		}
+	}
+
+	private void validateMimeType(MultipartFile file) {
+		String detectedMimeType = detectMimeType(file);
+		if (!config.getAllowedMimeTypes().contains(detectedMimeType)) {
+			throw new BusinessException(ErrorCode.FILE_MIME_TYPE_NOT_ALLOWED);
+		}
+	}
+
+	private String detectMimeType(MultipartFile file) {
+		try (InputStream inputStream = file.getInputStream()) {
+			Metadata metadata = new Metadata();
+			MediaType mediaType = DETECTOR.detect(inputStream, metadata);
+			return mediaType.toString();
+		} catch (IOException e) {
+			throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+		}
+	}
+
+	private void validateSize(MultipartFile file, FileType fileType) {
+		long maxSize = getMaxSize(fileType);
+		if (file.getSize() > maxSize) {
+			throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED);
+		}
+	}
+
+	private long getMaxSize(FileType fileType) {
+		return switch (fileType) {
+			case PROFILE_IMAGE -> config.getMaxProfileImageSize();
+			case GATHERING_IMAGE -> config.getMaxGatheringImageSize();
+		};
+	}
+}

--- a/src/main/java/com/gathering/file/application/FileValidator.java
+++ b/src/main/java/com/gathering/file/application/FileValidator.java
@@ -25,24 +25,25 @@ public class FileValidator {
 
 	private static final Detector DETECTOR = new DefaultDetector();
 
-	public static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp");
-	public static final Set<String> ALLOWED_MIME_TYPES = Set.of("image/jpeg", "image/png", "image/gif", "image/webp");
+	static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp");
+	static final Set<String> ALLOWED_MIME_TYPES = Set.of("image/jpeg", "image/png", "image/gif", "image/webp");
 
-	public void validate(MultipartFile file, FileType fileType) {
+	public String validate(MultipartFile file, FileType fileType) {
 		validateNotEmpty(file);
 		validateExtension(file.getOriginalFilename());
-		validateMimeType(file);
+		String detectedMimeType = validateMimeType(file);
 		validateSize(file, fileType);
+		return detectedMimeType;
 	}
 
-	public void validateNotEmpty(MultipartFile file) {
+	void validateNotEmpty(MultipartFile file) {
 		if (file == null || file.isEmpty()) {
 			log.warn("파일 검증 실패: 파일이 비어있음");
 			throw new BusinessException(ErrorCode.FILE_EMPTY);
 		}
 	}
 
-	public void validateExtension(String filename) {
+	void validateExtension(String filename) {
 		if (filename == null || !filename.contains(".")) {
 			log.warn("파일 검증 실패: 확장자 없음 - filename={}", filename);
 			throw new BusinessException(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
@@ -54,7 +55,7 @@ public class FileValidator {
 		}
 	}
 
-	public void validateMimeType(MultipartFile file) {
+	String validateMimeType(MultipartFile file) {
 		if (file == null) {
 			log.warn("파일 검증 실패: 파일이 null");
 			throw new BusinessException(ErrorCode.FILE_EMPTY);
@@ -64,6 +65,7 @@ public class FileValidator {
 			log.warn("파일 검증 실패: 허용되지 않는 MIME 타입 - filename={}, detectedMimeType={}, allowed={}", file.getOriginalFilename(), detectedMimeType, ALLOWED_MIME_TYPES);
 			throw new BusinessException(ErrorCode.FILE_MIME_TYPE_NOT_ALLOWED);
 		}
+		return detectedMimeType;
 	}
 
 	private String detectMimeType(MultipartFile file) {
@@ -77,7 +79,7 @@ public class FileValidator {
 		}
 	}
 
-	public void validateSize(MultipartFile file, FileType fileType) {
+	void validateSize(MultipartFile file, FileType fileType) {
 		if (file == null) {
 			log.warn("파일 검증 실패: 파일이 null");
 			throw new BusinessException(ErrorCode.FILE_EMPTY);

--- a/src/main/java/com/gathering/file/application/StorageResult.java
+++ b/src/main/java/com/gathering/file/application/StorageResult.java
@@ -1,0 +1,8 @@
+package com.gathering.file.application;
+
+public record StorageResult(
+	String publicUrl,
+	String storagePath,
+	String storedFilename
+) {
+}

--- a/src/main/java/com/gathering/file/application/StorageService.java
+++ b/src/main/java/com/gathering/file/application/StorageService.java
@@ -1,0 +1,10 @@
+package com.gathering.file.application;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageService {
+
+	StorageResult store(MultipartFile file, String directory);
+
+	void delete(String storagePath);
+}

--- a/src/main/java/com/gathering/file/domain/model/FileMetadataEntity.java
+++ b/src/main/java/com/gathering/file/domain/model/FileMetadataEntity.java
@@ -1,0 +1,77 @@
+package com.gathering.file.domain.model;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+	name = "file_metadata",
+	indexes = {
+		@Index(name = "idx_file_metadata_uploader_tsid", columnList = "uploader_tsid"),
+		@Index(name = "idx_file_metadata_file_type", columnList = "file_type")
+	}
+)
+public class FileMetadataEntity {
+
+	@Id
+	@Tsid
+	@Column(nullable = false, length = 13, columnDefinition = "CHAR(13)")
+	private String tsid;
+
+	@Column(name = "original_filename", nullable = false, length = 255)
+	private String originalFilename;
+
+	@Column(name = "stored_filename", nullable = false, length = 255)
+	private String storedFilename;
+
+	@Column(name = "storage_path", nullable = false, length = 500)
+	private String storagePath;
+
+	@Column(name = "mime_type", nullable = false, length = 100)
+	private String mimeType;
+
+	@Column(name = "file_size", nullable = false)
+	private long fileSize;
+
+	@Column(name = "uploader_tsid", nullable = false, length = 13, columnDefinition = "CHAR(13)")
+	private String uploaderTsid;
+
+	@Column(name = "file_type", nullable = false, length = 30)
+	@Enumerated(EnumType.STRING)
+	private FileType fileType;
+
+	@Column(name = "uploaded_at", nullable = false, updatable = false)
+	@CreatedDate
+	private Instant uploadedAt;
+
+	@Builder
+	public FileMetadataEntity(String originalFilename, String storedFilename, String storagePath,
+		String mimeType, long fileSize, String uploaderTsid, FileType fileType) {
+		this.originalFilename = originalFilename;
+		this.storedFilename = storedFilename;
+		this.storagePath = storagePath;
+		this.mimeType = mimeType;
+		this.fileSize = fileSize;
+		this.uploaderTsid = uploaderTsid;
+		this.fileType = fileType;
+	}
+}

--- a/src/main/java/com/gathering/file/domain/model/FileType.java
+++ b/src/main/java/com/gathering/file/domain/model/FileType.java
@@ -1,0 +1,6 @@
+package com.gathering.file.domain.model;
+
+public enum FileType {
+	PROFILE_IMAGE,
+	GATHERING_IMAGE
+}

--- a/src/main/java/com/gathering/file/domain/model/FileType.java
+++ b/src/main/java/com/gathering/file/domain/model/FileType.java
@@ -1,6 +1,13 @@
 package com.gathering.file.domain.model;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum FileType {
-	PROFILE_IMAGE,
-	GATHERING_IMAGE
+	PROFILE_IMAGE(5 * 1024 * 1024L),
+	GATHERING_IMAGE(10 * 1024 * 1024L);
+
+	private final long maxSize;
 }

--- a/src/main/java/com/gathering/file/domain/repository/FileMetadataRepository.java
+++ b/src/main/java/com/gathering/file/domain/repository/FileMetadataRepository.java
@@ -1,0 +1,13 @@
+package com.gathering.file.domain.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.gathering.file.domain.model.FileMetadataEntity;
+import com.gathering.file.domain.model.FileType;
+
+public interface FileMetadataRepository extends JpaRepository<FileMetadataEntity, String> {
+
+	List<FileMetadataEntity> findByUploaderTsidAndFileType(String uploaderTsid, FileType fileType);
+}

--- a/src/main/java/com/gathering/file/infra/FileUploadConfig.java
+++ b/src/main/java/com/gathering/file/infra/FileUploadConfig.java
@@ -1,7 +1,5 @@
 package com.gathering.file.infra;
 
-import java.util.List;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -14,10 +12,6 @@ import lombok.Setter;
 @ConfigurationProperties(prefix = "file.upload")
 public class FileUploadConfig {
 
-	private List<String> allowedExtensions = List.of("jpg", "jpeg", "png", "gif", "webp");
-	private List<String> allowedMimeTypes = List.of("image/jpeg", "image/png", "image/gif", "image/webp");
-	private long maxProfileImageSize = 5 * 1024 * 1024L;    // 5MB
-	private long maxGatheringImageSize = 10 * 1024 * 1024L; // 10MB
-	private String localUploadPath = "uploads";
-	private String urlPrefix = "/uploads";
+	private String localUploadPath;
+	private String urlPrefix;
 }

--- a/src/main/java/com/gathering/file/infra/FileUploadConfig.java
+++ b/src/main/java/com/gathering/file/infra/FileUploadConfig.java
@@ -1,0 +1,23 @@
+package com.gathering.file.infra;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "file.upload")
+public class FileUploadConfig {
+
+	private List<String> allowedExtensions = List.of("jpg", "jpeg", "png", "gif", "webp");
+	private List<String> allowedMimeTypes = List.of("image/jpeg", "image/png", "image/gif", "image/webp");
+	private long maxProfileImageSize = 5 * 1024 * 1024L;    // 5MB
+	private long maxGatheringImageSize = 10 * 1024 * 1024L; // 10MB
+	private String localUploadPath = "uploads";
+	private String urlPrefix = "/uploads";
+}

--- a/src/main/java/com/gathering/file/infra/FileUploadWebMvcConfig.java
+++ b/src/main/java/com/gathering/file/infra/FileUploadWebMvcConfig.java
@@ -1,0 +1,22 @@
+package com.gathering.file.infra;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@Profile({"default", "test"})
+@RequiredArgsConstructor
+public class FileUploadWebMvcConfig implements WebMvcConfigurer {
+
+	private final FileUploadConfig config;
+
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		registry.addResourceHandler(config.getUrlPrefix() + "/**")
+			.addResourceLocations("file:" + config.getLocalUploadPath() + "/");
+	}
+}

--- a/src/main/java/com/gathering/file/infra/LocalStorageService.java
+++ b/src/main/java/com/gathering/file/infra/LocalStorageService.java
@@ -52,7 +52,8 @@ public class LocalStorageService implements StorageService {
 		try {
 			Files.deleteIfExists(filePath);
 		} catch (IOException e) {
-			log.warn("파일 삭제 실패: {}", storagePath, e);
+			log.error("파일 삭제 실패 - storagePath={}", storagePath, e);
+			throw new BusinessException(ErrorCode.FILE_DELETE_FAILED, e);
 		}
 	}
 

--- a/src/main/java/com/gathering/file/infra/LocalStorageService.java
+++ b/src/main/java/com/gathering/file/infra/LocalStorageService.java
@@ -59,7 +59,8 @@ public class LocalStorageService implements StorageService {
 
 	private String extractExtension(String filename) {
 		if (filename == null || !filename.contains(".")) {
-			return "";
+			log.error("파일 저장 실패: 확장자를 추출할 수 없음 - filename={}", filename);
+			throw new BusinessException(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
 		}
 		return filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
 	}

--- a/src/main/java/com/gathering/file/infra/LocalStorageService.java
+++ b/src/main/java/com/gathering/file/infra/LocalStorageService.java
@@ -1,0 +1,65 @@
+package com.gathering.file.infra;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.gathering.common.exception.BusinessException;
+import com.gathering.common.exception.ErrorCode;
+import com.gathering.file.application.StorageResult;
+import com.gathering.file.application.StorageService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Profile({"default", "test"})
+@RequiredArgsConstructor
+public class LocalStorageService implements StorageService {
+
+	private final FileUploadConfig config;
+
+	@Override
+	public StorageResult store(MultipartFile file, String directory) {
+		String originalFilename = file.getOriginalFilename();
+		String extension = extractExtension(originalFilename);
+		String storedFilename = UUID.randomUUID() + "." + extension;
+		String storagePath = directory + "/" + storedFilename;
+
+		Path uploadDir = Paths.get(config.getLocalUploadPath(), directory);
+		try {
+			Files.createDirectories(uploadDir);
+			Path targetPath = uploadDir.resolve(storedFilename);
+			file.transferTo(targetPath.toFile());
+		} catch (IOException e) {
+			throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED, e);
+		}
+
+		String publicUrl = config.getUrlPrefix() + "/" + storagePath;
+		return new StorageResult(publicUrl, storagePath, storedFilename);
+	}
+
+	@Override
+	public void delete(String storagePath) {
+		Path filePath = Paths.get(config.getLocalUploadPath(), storagePath);
+		try {
+			Files.deleteIfExists(filePath);
+		} catch (IOException e) {
+			log.warn("파일 삭제 실패: {}", storagePath, e);
+		}
+	}
+
+	private String extractExtension(String filename) {
+		if (filename == null || !filename.contains(".")) {
+			return "";
+		}
+		return filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
+	}
+}

--- a/src/main/java/com/gathering/file/infra/LocalStorageService.java
+++ b/src/main/java/com/gathering/file/infra/LocalStorageService.java
@@ -33,7 +33,7 @@ public class LocalStorageService implements StorageService {
 		String storedFilename = UUID.randomUUID() + "." + extension;
 		String storagePath = directory + "/" + storedFilename;
 
-		Path uploadDir = Paths.get(config.getLocalUploadPath(), directory);
+		Path uploadDir = Paths.get(config.getLocalUploadPath(), directory).toAbsolutePath();
 		try {
 			Files.createDirectories(uploadDir);
 			Path targetPath = uploadDir.resolve(storedFilename);
@@ -48,7 +48,7 @@ public class LocalStorageService implements StorageService {
 
 	@Override
 	public void delete(String storagePath) {
-		Path filePath = Paths.get(config.getLocalUploadPath(), storagePath);
+		Path filePath = Paths.get(config.getLocalUploadPath(), storagePath).toAbsolutePath();
 		try {
 			Files.deleteIfExists(filePath);
 		} catch (IOException e) {

--- a/src/main/java/com/gathering/file/infra/S3StorageService.java
+++ b/src/main/java/com/gathering/file/infra/S3StorageService.java
@@ -1,0 +1,35 @@
+package com.gathering.file.infra;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.gathering.file.application.StorageResult;
+import com.gathering.file.application.StorageService;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * S3 기반 파일 저장소 (운영 환경)
+ * TODO: AWS SDK v2를 사용하여 실제 S3 업로드 구현 필요
+ *       - CloudFront OAC(Origin Access Control)를 통한 파일 서빙
+ *       - 버킷 정책: public 접근 차단, CloudFront OAC만 허용
+ */
+@Slf4j
+@Service
+@Profile("prod")
+public class S3StorageService implements StorageService {
+
+	@Override
+	public StorageResult store(MultipartFile file, String directory) {
+		// TODO: AWS SDK v2 S3Client 구현
+		log.warn("S3StorageService.store() 는 아직 구현되지 않았습니다. directory={}", directory);
+		throw new UnsupportedOperationException("S3 업로드는 아직 구현되지 않았습니다.");
+	}
+
+	@Override
+	public void delete(String storagePath) {
+		// TODO: AWS SDK v2 S3Client deleteObject 구현
+		log.warn("S3StorageService.delete() 는 아직 구현되지 않았습니다. storagePath={}", storagePath);
+	}
+}

--- a/src/main/java/com/gathering/file/presentation/dto/FileUploadResponse.java
+++ b/src/main/java/com/gathering/file/presentation/dto/FileUploadResponse.java
@@ -1,0 +1,4 @@
+package com.gathering.file.presentation.dto;
+
+public record FileUploadResponse(String url) {
+}

--- a/src/main/java/com/gathering/gathering/application/GatheringService.java
+++ b/src/main/java/com/gathering/gathering/application/GatheringService.java
@@ -1,0 +1,48 @@
+package com.gathering.gathering.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.gathering.common.exception.BusinessException;
+import com.gathering.common.exception.ErrorCode;
+import com.gathering.file.application.FileUploadService;
+import com.gathering.file.domain.model.FileType;
+import com.gathering.gathering.domain.model.GatheringEntity;
+import com.gathering.gathering.domain.model.ParticipantRole;
+import com.gathering.gathering.domain.repository.GatheringParticipantRepository;
+import com.gathering.gathering.domain.repository.GatheringRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GatheringService {
+
+	private final GatheringRepository gatheringRepository;
+	private final GatheringParticipantRepository gatheringParticipantRepository;
+	private final FileUploadService fileUploadService;
+
+	/**
+	 * 모임 대표 이미지 업로드
+	 * OWNER 권한이 있는 사용자만 업로드 가능
+	 *
+	 * @param gatheringTsid 모임 TSID
+	 * @param requesterTsid 요청자 TSID
+	 * @param file 업로드할 이미지 파일
+	 * @return 업로드된 파일의 공개 URL
+	 */
+	@Transactional
+	public String uploadMainImage(String gatheringTsid, String requesterTsid, MultipartFile file) {
+		GatheringEntity gathering = gatheringRepository.findById(gatheringTsid)
+			.orElseThrow(() -> new BusinessException(ErrorCode.GATHERING_NOT_FOUND));
+
+		gatheringParticipantRepository.findByGatheringTsidAndUserTsidAndRole(
+				gatheringTsid, requesterTsid, ParticipantRole.OWNER)
+			.orElseThrow(() -> new BusinessException(ErrorCode.GATHERING_ACCESS_DENIED));
+
+		String url = fileUploadService.upload(file, FileType.GATHERING_IMAGE, requesterTsid);
+		gathering.updateMainImageUrl(url);
+		return url;
+	}
+}

--- a/src/main/java/com/gathering/gathering/domain/model/GatheringEntity.java
+++ b/src/main/java/com/gathering/gathering/domain/model/GatheringEntity.java
@@ -67,6 +67,10 @@ public class GatheringEntity {
 	@CreatedDate
 	private Instant createdAt;
 
+	public void updateMainImageUrl(String mainImageUrl) {
+		this.mainImageUrl = mainImageUrl;
+	}
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(
 		name = "region_tsid",

--- a/src/main/java/com/gathering/gathering/domain/repository/GatheringParticipantRepository.java
+++ b/src/main/java/com/gathering/gathering/domain/repository/GatheringParticipantRepository.java
@@ -1,8 +1,14 @@
 package com.gathering.gathering.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.gathering.gathering.domain.model.GatheringParticipantEntity;
+import com.gathering.gathering.domain.model.ParticipantRole;
 
 public interface GatheringParticipantRepository extends JpaRepository<GatheringParticipantEntity, String> {
+
+	Optional<GatheringParticipantEntity> findByGatheringTsidAndUserTsidAndRole(
+		String gatheringTsid, String userTsid, ParticipantRole role);
 }

--- a/src/main/java/com/gathering/gathering/presentation/controller/GatheringController.java
+++ b/src/main/java/com/gathering/gathering/presentation/controller/GatheringController.java
@@ -1,0 +1,40 @@
+package com.gathering.gathering.presentation.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.gathering.auth.application.AuthService;
+import com.gathering.file.presentation.dto.FileUploadResponse;
+import com.gathering.gathering.application.GatheringService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/gatherings")
+@RestController
+@RequiredArgsConstructor
+public class GatheringController {
+
+	private final GatheringService gatheringService;
+	private final AuthService authService;
+
+	/**
+	 * 모임 대표 이미지 업로드
+	 * OWNER 권한을 가진 사용자만 업로드 가능
+	 */
+	@PatchMapping(value = "/{tsid}/main-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<FileUploadResponse> uploadMainImage(
+		@PathVariable String tsid,
+		HttpServletRequest request,
+		@RequestPart("file") MultipartFile file) {
+		String requesterTsid = authService.getCurrentUserTsid(request);
+		String url = gatheringService.uploadMainImage(tsid, requesterTsid, file);
+		return ResponseEntity.ok(new FileUploadResponse(url));
+	}
+}

--- a/src/main/java/com/gathering/user/application/UserService.java
+++ b/src/main/java/com/gathering/user/application/UserService.java
@@ -4,11 +4,14 @@ import java.util.List;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.gathering.auth.application.RefreshTokenService;
 import com.gathering.auth.domain.OAuthUserInfo;
 import com.gathering.common.exception.BusinessException;
 import com.gathering.common.exception.ErrorCode;
+import com.gathering.file.application.FileUploadService;
+import com.gathering.file.domain.model.FileType;
 import com.gathering.user.domain.model.OAuthProvider;
 import com.gathering.user.domain.model.UserOAuthConnectionEntity;
 import com.gathering.user.domain.model.UserSecurityEntity;
@@ -35,6 +38,7 @@ public class UserService {
 	private final PasswordEncoder passwordEncoder;
 	private final UserValidator userValidator;
 	private final RefreshTokenService refreshTokenService;
+	private final FileUploadService fileUploadService;
 
 	/**
 	 * 회원가입 처리
@@ -72,6 +76,22 @@ public class UserService {
 		userSecurityRepository.save(userSecurityEntity);
 
 		return usersEntity;
+	}
+
+	/**
+	 * 프로필 이미지 업로드
+	 * 기존 이미지가 있으면 커밋 후 삭제 (롤백 시 기존 이미지 보존)
+	 *
+	 * @param tsid 사용자 고유 ID
+	 * @param file 업로드할 이미지 파일
+	 * @return 업로드된 파일의 공개 URL
+	 */
+	@Transactional
+	public String uploadProfileImage(String tsid, MultipartFile file) {
+		UsersEntity user = getUsersEntityByTsid(tsid);
+		String url = fileUploadService.upload(file, FileType.PROFILE_IMAGE, tsid);
+		user.updateProfileImageUrl(url);
+		return url;
 	}
 
 	/**

--- a/src/main/java/com/gathering/user/application/UserService.java
+++ b/src/main/java/com/gathering/user/application/UserService.java
@@ -25,7 +25,7 @@ import com.gathering.user.presentation.dto.UpdateMyInfoRequest;
 import com.gathering.user.presentation.dto.UserJoinRequest;
 import com.gathering.user.presentation.dto.WithdrawRequest;
 
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -107,16 +107,14 @@ public class UserService {
 	@Transactional
 	public void deleteProfileImage(String tsid) {
 		UsersEntity user = getUsersEntityByTsid(tsid);
-		if (user.getProfileImageUrl() == null) {
+
+		var metadataList = fileUploadService.findFilesByUploaderAndType(tsid, FileType.PROFILE_IMAGE);
+		if (metadataList.isEmpty()) {
 			return;
 		}
 
-		var metadataList = fileUploadService.findFilesByUploaderAndType(tsid, FileType.PROFILE_IMAGE);
 		user.updateProfileImageUrl(null);
-
-		if (!metadataList.isEmpty()) {
-			fileUploadService.deleteFilesWithCleanup(metadataList);
-		}
+		fileUploadService.deleteFilesWithCleanup(metadataList);
 	}
 
 	/**

--- a/src/main/java/com/gathering/user/application/UserService.java
+++ b/src/main/java/com/gathering/user/application/UserService.java
@@ -89,9 +89,34 @@ public class UserService {
 	@Transactional
 	public String uploadProfileImage(String tsid, MultipartFile file) {
 		UsersEntity user = getUsersEntityByTsid(tsid);
+
+		// 업로드 전에 기존 이미지 메타데이터 조회 (새 이미지와 구분하기 위해 먼저 조회)
+		var oldMetadata = fileUploadService.findFilesByUploaderAndType(tsid, FileType.PROFILE_IMAGE);
+
 		String url = fileUploadService.upload(file, FileType.PROFILE_IMAGE, tsid);
 		user.updateProfileImageUrl(url);
+
+		// 기존 이미지 메타데이터 DB 삭제 + 커밋 후 스토리지 파일 삭제
+		if (!oldMetadata.isEmpty()) {
+			fileUploadService.deleteFilesWithCleanup(oldMetadata);
+		}
+
 		return url;
+	}
+
+	@Transactional
+	public void deleteProfileImage(String tsid) {
+		UsersEntity user = getUsersEntityByTsid(tsid);
+		if (user.getProfileImageUrl() == null) {
+			return;
+		}
+
+		var metadataList = fileUploadService.findFilesByUploaderAndType(tsid, FileType.PROFILE_IMAGE);
+		user.updateProfileImageUrl(null);
+
+		if (!metadataList.isEmpty()) {
+			fileUploadService.deleteFilesWithCleanup(metadataList);
+		}
 	}
 
 	/**

--- a/src/main/java/com/gathering/user/domain/model/UsersEntity.java
+++ b/src/main/java/com/gathering/user/domain/model/UsersEntity.java
@@ -68,6 +68,11 @@ public class UsersEntity {
 	@CreatedDate
 	private Instant createdAt;
 
+
+	public void updateProfileImageUrl(String profileImageUrl) {
+		this.profileImageUrl = profileImageUrl;
+	}
+
 	/**
 	 * 프로필 정보 업데이트
 	 * JPA 엔티티이므로 필드를 직접 변경하면 dirty checking으로 자동 UPDATE

--- a/src/main/java/com/gathering/user/presentation/controller/UsersController.java
+++ b/src/main/java/com/gathering/user/presentation/controller/UsersController.java
@@ -1,5 +1,6 @@
 package com.gathering.user.presentation.controller;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,9 +10,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.gathering.auth.application.AuthService;
+import com.gathering.file.presentation.dto.FileUploadResponse;
 import com.gathering.user.application.UserService;
 import com.gathering.user.domain.model.OAuthProvider;
 import com.gathering.user.domain.model.UsersEntity;
@@ -57,6 +61,18 @@ public class UsersController {
 		String tsid = authService.getCurrentUserTsid(request);
 		MyInfoResponse response = userService.getMyInfo(tsid);
 		return ResponseEntity.ok(response);
+	}
+
+	/**
+	 * 프로필 이미지 업로드
+	 */
+	@PatchMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<FileUploadResponse> uploadProfileImage(
+		HttpServletRequest request,
+		@RequestPart("file") MultipartFile file) {
+		String tsid = authService.getCurrentUserTsid(request);
+		String url = userService.uploadProfileImage(tsid, file);
+		return ResponseEntity.ok(new FileUploadResponse(url));
 	}
 
 	/**

--- a/src/main/java/com/gathering/user/presentation/controller/UsersController.java
+++ b/src/main/java/com/gathering/user/presentation/controller/UsersController.java
@@ -76,6 +76,16 @@ public class UsersController {
 	}
 
 	/**
+	 * 프로필 이미지 삭제
+	 */
+	@DeleteMapping("/me/profile-image")
+	public ResponseEntity<Void> deleteProfileImage(HttpServletRequest request) {
+		String tsid = authService.getCurrentUserTsid(request);
+		userService.deleteProfileImage(tsid);
+		return ResponseEntity.noContent().build();
+	}
+
+	/**
 	 * 내 정보 수정
 	 */
 	@PatchMapping("/me")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -75,19 +75,6 @@ jwt:
 
 file:
   upload:
-    allowed-extensions:
-      - jpg
-      - jpeg
-      - png
-      - gif
-      - webp
-    allowed-mime-types:
-      - image/jpeg
-      - image/png
-      - image/gif
-      - image/webp
-    max-profile-image-size: 5242880   # 5MB
-    max-gathering-image-size: 10485760 # 10MB
     local-upload-path: uploads
     url-prefix: /uploads
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,6 +45,11 @@ spring:
     restart:
       enabled: true
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   # Redis 설정
   data:
     redis:
@@ -67,4 +72,22 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-validity-in-seconds: 3600 # 1시간
   refresh-token-validity-in-seconds: 7776000 # 90일
+
+file:
+  upload:
+    allowed-extensions:
+      - jpg
+      - jpeg
+      - png
+      - gif
+      - webp
+    allowed-mime-types:
+      - image/jpeg
+      - image/png
+      - image/gif
+      - image/webp
+    max-profile-image-size: 5242880   # 5MB
+    max-gathering-image-size: 10485760 # 10MB
+    local-upload-path: uploads
+    url-prefix: /uploads
 

--- a/src/main/resources/templates/user/my-info.html
+++ b/src/main/resources/templates/user/my-info.html
@@ -113,6 +113,18 @@
             margin-bottom: 30px;
         }
 
+        .profile-image-wrapper {
+            position: relative;
+            width: 80px;
+            height: 80px;
+            cursor: pointer;
+            flex-shrink: 0;
+        }
+
+        .profile-image-wrapper:hover .profile-image-overlay {
+            background: #0773c5;
+        }
+
         .profile-image {
             width: 80px;
             height: 80px;
@@ -123,6 +135,33 @@
             align-items: center;
             justify-content: center;
             font-size: 2rem;
+            overflow: hidden;
+        }
+
+        .profile-image img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .profile-image.uploading {
+            opacity: 0.5;
+        }
+
+        .profile-image-overlay {
+            position: absolute;
+            bottom: 0;
+            right: 0;
+            width: 26px;
+            height: 26px;
+            background: #0984e3;
+            border: 2px solid white;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.75rem;
+            transition: background 0.2s ease;
         }
 
         .profile-info {
@@ -509,12 +548,17 @@
     <div id="contentSection" class="content-section">
         <!-- 프로필 헤더 -->
         <div class="profile-header">
-            <div class="profile-image">👤</div>
+            <div class="profile-image-wrapper" onclick="document.getElementById('profileImageInput').click()" title="클릭하여 프로필 이미지 변경">
+                <div class="profile-image" id="profileImageContainer">👤</div>
+                <div class="profile-image-overlay">📷</div>
+            </div>
+            <input type="file" id="profileImageInput" accept="image/jpeg,image/png,image/gif,image/webp" style="display:none">
             <div class="profile-info">
                 <div class="profile-nickname" id="displayNickname">닉네임</div>
                 <div class="profile-email" id="displayEmail">email@example.com</div>
             </div>
         </div>
+        <div id="imageUploadAlert" class="alert"></div>
 
         <!-- 프로필 수정 폼 -->
         <div class="section-title">프로필 정보 수정</div>
@@ -836,6 +880,13 @@
         document.getElementById('displayNickname').textContent = data.nickname || '닉네임 없음';
         document.getElementById('displayEmail').textContent = data.email;
 
+        const profileImageContainer = document.getElementById('profileImageContainer');
+        if (data.profileImageUrl) {
+            profileImageContainer.innerHTML = `<img src="${data.profileImageUrl}" alt="프로필 이미지">`;
+        } else {
+            profileImageContainer.textContent = '👤';
+        }
+
         document.getElementById('nickname').value = data.nickname || '';
         document.getElementById('name').value = data.name || '';
         document.getElementById('phoneNumber').value = data.phoneNumber || '';
@@ -971,6 +1022,55 @@
     function validatePassword(password) {
         const passwordRegex = /^(?=.*\d)(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}$/;
         return passwordRegex.test(password);
+    }
+
+    // 프로필 이미지 파일 선택
+    document.getElementById('profileImageInput').addEventListener('change', async function (e) {
+        const file = e.target.files[0];
+        if (!file) return;
+        await uploadProfileImage(file);
+        e.target.value = '';
+    });
+
+    // 프로필 이미지 업로드
+    async function uploadProfileImage(file) {
+        const profileImageContainer = document.getElementById('profileImageContainer');
+        const wrapper = profileImageContainer.closest('.profile-image-wrapper');
+
+        wrapper.style.pointerEvents = 'none';
+        profileImageContainer.classList.add('uploading');
+
+        try {
+            const accessToken = localStorage.getItem('accessToken');
+            const formData = new FormData();
+            formData.append('file', file);
+
+            const response = await fetch('/users/me/profile-image', {
+                method: 'PATCH',
+                headers: {
+                    ...(accessToken && {'Authorization': `Bearer ${accessToken}`})
+                },
+                body: formData
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                profileImageContainer.innerHTML = `<img src="${data.url}" alt="프로필 이미지">`;
+                showAlert('imageUploadAlert', 'success', '프로필 이미지가 업데이트되었습니다.');
+            } else if (response.status === 401) {
+                const refreshed = await refreshAccessToken();
+                if (refreshed) await uploadProfileImage(file);
+            } else {
+                const errorData = await response.json().catch(() => null);
+                showAlert('imageUploadAlert', 'error', errorData?.message || '이미지 업로드에 실패했습니다.');
+            }
+        } catch (error) {
+            console.error('프로필 이미지 업로드 실패:', error);
+            showAlert('imageUploadAlert', 'error', '서버 연결에 실패했습니다. 잠시 후 다시 시도해주세요.');
+        } finally {
+            wrapper.style.pointerEvents = '';
+            profileImageContainer.classList.remove('uploading');
+        }
     }
 
     // 프로필 수정 폼 제출

--- a/src/main/resources/templates/user/my-info.html
+++ b/src/main/resources/templates/user/my-info.html
@@ -162,6 +162,30 @@
             justify-content: center;
             font-size: 0.75rem;
             transition: background 0.2s ease;
+            cursor: pointer;
+        }
+
+        .profile-image-delete {
+            position: absolute;
+            top: 0;
+            right: 0;
+            width: 22px;
+            height: 22px;
+            background: #e74c3c;
+            border: 2px solid white;
+            border-radius: 50%;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.65rem;
+            color: white;
+            cursor: pointer;
+            transition: background 0.2s ease;
+            padding: 0;
+        }
+
+        .profile-image-delete:hover {
+            background: #c0392b;
         }
 
         .profile-info {
@@ -548,9 +572,10 @@
     <div id="contentSection" class="content-section">
         <!-- 프로필 헤더 -->
         <div class="profile-header">
-            <div class="profile-image-wrapper" onclick="document.getElementById('profileImageInput').click()" title="클릭하여 프로필 이미지 변경">
-                <div class="profile-image" id="profileImageContainer">👤</div>
-                <div class="profile-image-overlay">📷</div>
+            <div class="profile-image-wrapper" id="profileImageWrapper">
+                <div class="profile-image" id="profileImageContainer" onclick="document.getElementById('profileImageInput').click()" title="클릭하여 프로필 이미지 변경">👤</div>
+                <div class="profile-image-overlay" onclick="document.getElementById('profileImageInput').click()" title="클릭하여 프로필 이미지 변경">📷</div>
+                <button class="profile-image-delete" id="profileImageDeleteBtn" onclick="deleteProfileImage()" title="프로필 이미지 삭제">✕</button>
             </div>
             <input type="file" id="profileImageInput" accept="image/jpeg,image/png,image/gif,image/webp" style="display:none">
             <div class="profile-info">
@@ -880,12 +905,7 @@
         document.getElementById('displayNickname').textContent = data.nickname || '닉네임 없음';
         document.getElementById('displayEmail').textContent = data.email;
 
-        const profileImageContainer = document.getElementById('profileImageContainer');
-        if (data.profileImageUrl) {
-            profileImageContainer.innerHTML = `<img src="${data.profileImageUrl}" alt="프로필 이미지">`;
-        } else {
-            profileImageContainer.textContent = '👤';
-        }
+        setProfileImage(data.profileImageUrl);
 
         document.getElementById('nickname').value = data.nickname || '';
         document.getElementById('name').value = data.name || '';
@@ -1032,13 +1052,26 @@
         e.target.value = '';
     });
 
+    // 프로필 이미지 상태 반영 (이미지 표시 + 삭제 버튼 노출 여부)
+    function setProfileImage(url) {
+        const container = document.getElementById('profileImageContainer');
+        const deleteBtn = document.getElementById('profileImageDeleteBtn');
+        if (url) {
+            container.innerHTML = `<img src="${url}" alt="프로필 이미지">`;
+            deleteBtn.style.display = 'flex';
+        } else {
+            container.textContent = '👤';
+            deleteBtn.style.display = 'none';
+        }
+    }
+
     // 프로필 이미지 업로드
     async function uploadProfileImage(file) {
-        const profileImageContainer = document.getElementById('profileImageContainer');
-        const wrapper = profileImageContainer.closest('.profile-image-wrapper');
+        const wrapper = document.getElementById('profileImageWrapper');
+        const container = document.getElementById('profileImageContainer');
 
         wrapper.style.pointerEvents = 'none';
-        profileImageContainer.classList.add('uploading');
+        container.classList.add('uploading');
 
         try {
             const accessToken = localStorage.getItem('accessToken');
@@ -1055,7 +1088,7 @@
 
             if (response.ok) {
                 const data = await response.json();
-                profileImageContainer.innerHTML = `<img src="${data.url}" alt="프로필 이미지">`;
+                setProfileImage(data.url);
                 showAlert('imageUploadAlert', 'success', '프로필 이미지가 업데이트되었습니다.');
             } else if (response.status === 401) {
                 const refreshed = await refreshAccessToken();
@@ -1069,7 +1102,45 @@
             showAlert('imageUploadAlert', 'error', '서버 연결에 실패했습니다. 잠시 후 다시 시도해주세요.');
         } finally {
             wrapper.style.pointerEvents = '';
-            profileImageContainer.classList.remove('uploading');
+            container.classList.remove('uploading');
+        }
+    }
+
+    // 프로필 이미지 삭제
+    async function deleteProfileImage() {
+        if (!confirm('프로필 이미지를 삭제하시겠습니까?')) return;
+
+        const wrapper = document.getElementById('profileImageWrapper');
+        const deleteBtn = document.getElementById('profileImageDeleteBtn');
+
+        wrapper.style.pointerEvents = 'none';
+        deleteBtn.textContent = '...';
+
+        try {
+            const accessToken = localStorage.getItem('accessToken');
+            const response = await fetch('/users/me/profile-image', {
+                method: 'DELETE',
+                headers: {
+                    ...(accessToken && {'Authorization': `Bearer ${accessToken}`})
+                }
+            });
+
+            if (response.ok) {
+                setProfileImage(null);
+                showAlert('imageUploadAlert', 'success', '프로필 이미지가 삭제되었습니다.');
+            } else if (response.status === 401) {
+                const refreshed = await refreshAccessToken();
+                if (refreshed) await deleteProfileImage();
+            } else {
+                const errorData = await response.json().catch(() => null);
+                showAlert('imageUploadAlert', 'error', errorData?.message || '이미지 삭제에 실패했습니다.');
+            }
+        } catch (error) {
+            console.error('프로필 이미지 삭제 실패:', error);
+            showAlert('imageUploadAlert', 'error', '서버 연결에 실패했습니다. 잠시 후 다시 시도해주세요.');
+        } finally {
+            wrapper.style.pointerEvents = '';
+            deleteBtn.textContent = '✕';
         }
     }
 

--- a/src/test/java/com/gathering/file/FileUploadServiceTest.java
+++ b/src/test/java/com/gathering/file/FileUploadServiceTest.java
@@ -1,0 +1,91 @@
+package com.gathering.file;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.gathering.common.exception.BusinessException;
+import com.gathering.common.exception.ErrorCode;
+import com.gathering.file.application.FileUploadService;
+import com.gathering.file.application.FileValidator;
+import com.gathering.file.application.StorageResult;
+import com.gathering.file.application.StorageService;
+import com.gathering.file.domain.model.FileMetadataEntity;
+import com.gathering.file.domain.model.FileType;
+import com.gathering.file.domain.repository.FileMetadataRepository;
+
+@DisplayName("FileUploadService 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class FileUploadServiceTest {
+
+	@InjectMocks
+	private FileUploadService fileUploadService;
+
+	@Mock
+	private FileValidator fileValidator;
+
+	@Mock
+	private StorageService storageService;
+
+	@Mock
+	private FileMetadataRepository fileMetadataRepository;
+
+	@Test
+	@DisplayName("성공적인 업로드 - URL 반환, 메타데이터 저장")
+	void upload_success_returnsUrlAndSavesMetadata() {
+		// given
+		MultipartFile file = createValidJpegFile();
+		String uploaderTsid = "testUserTsid00";
+		StorageResult storageResult = new StorageResult(
+			"/uploads/profile-images/uuid.jpg",
+			"profile-images/uuid.jpg",
+			"uuid.jpg"
+		);
+
+		willDoNothing().given(fileValidator).validate(any(), any());
+		given(storageService.store(any(), anyString())).willReturn(storageResult);
+		given(fileMetadataRepository.save(any(FileMetadataEntity.class))).willAnswer(i -> i.getArgument(0));
+
+		// when
+		String resultUrl = fileUploadService.upload(file, FileType.PROFILE_IMAGE, uploaderTsid);
+
+		// then
+		assertThat(resultUrl).isEqualTo("/uploads/profile-images/uuid.jpg");
+		then(fileMetadataRepository).should().save(any(FileMetadataEntity.class));
+	}
+
+	@Test
+	@DisplayName("저장소 쓰기 실패 - FILE_UPLOAD_FAILED 예외, 메타데이터 미저장")
+	void upload_storageFailure_throwsFileUploadFailed() {
+		// given
+		MultipartFile file = createValidJpegFile();
+		willDoNothing().given(fileValidator).validate(any(), any());
+		given(storageService.store(any(), anyString()))
+			.willThrow(new BusinessException(ErrorCode.FILE_UPLOAD_FAILED));
+
+		// when & then
+		assertThatThrownBy(() -> fileUploadService.upload(file, FileType.PROFILE_IMAGE, "uploaderTsid"))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException)e).getErrorCode())
+			.isEqualTo(ErrorCode.FILE_UPLOAD_FAILED);
+
+		then(fileMetadataRepository).should(never()).save(any());
+	}
+
+	private MultipartFile createValidJpegFile() {
+		byte[] content = new byte[1024];
+		content[0] = (byte)0xFF;
+		content[1] = (byte)0xD8;
+		content[2] = (byte)0xFF;
+		return new MockMultipartFile("file", "test.jpg", "image/jpeg", content);
+	}
+}

--- a/src/test/java/com/gathering/file/FileValidatorTest.java
+++ b/src/test/java/com/gathering/file/FileValidatorTest.java
@@ -1,0 +1,223 @@
+package com.gathering.file;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.gathering.common.exception.BusinessException;
+import com.gathering.common.exception.ErrorCode;
+import com.gathering.file.application.FileValidator;
+import com.gathering.file.domain.model.FileType;
+import com.gathering.file.infra.FileUploadConfig;
+
+@DisplayName("FileValidator 단위 테스트")
+class FileValidatorTest {
+
+	private FileValidator fileValidator;
+
+	@BeforeEach
+	void setUp() {
+		FileUploadConfig config = new FileUploadConfig();
+		fileValidator = new FileValidator(config);
+	}
+
+	// ────────────── 정상 케이스 ──────────────
+
+	@Test
+	@DisplayName("정상 JPEG 파일 (2MB) - 예외 없음")
+	void validate_validJpeg_noException() throws IOException {
+		MultipartFile file = createFakeJpegFile("photo.jpg", 2 * 1024 * 1024);
+		assertThatNoException().isThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE));
+	}
+
+	@Test
+	@DisplayName("정상 PNG 파일 (1MB) - 예외 없음")
+	void validate_validPng_noException() throws IOException {
+		MultipartFile file = createFakePngFile("image.png", 1024 * 1024);
+		assertThatNoException().isThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE));
+	}
+
+	@Test
+	@DisplayName("정상 WebP 파일 (3MB) - 예외 없음")
+	void validate_validWebp_noException() throws IOException {
+		MultipartFile file = createFakeWebpFile("image.webp", 3 * 1024 * 1024);
+		assertThatNoException().isThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE));
+	}
+
+	@Test
+	@DisplayName("대문자 확장자 (PHOTO.JPG) - 예외 없음")
+	void validate_uppercaseExtension_noException() throws IOException {
+		MultipartFile file = createFakeJpegFile("PHOTO.JPG", 1024 * 1024);
+		assertThatNoException().isThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE));
+	}
+
+	@Test
+	@DisplayName("모임 이미지 7MB - 프로필 제한(5MB) 초과지만 모임 이미지 제한(10MB) 이내 - 예외 없음")
+	void validate_gatheringImage7MB_noException() throws IOException {
+		MultipartFile file = createFakeJpegFile("gathering.jpg", 7 * 1024 * 1024);
+		assertThatNoException().isThrownBy(() -> fileValidator.validate(file, FileType.GATHERING_IMAGE));
+	}
+
+	// ────────────── 파일 비어있음 ──────────────
+
+	@Test
+	@DisplayName("null 파일 - FILE_EMPTY 예외")
+	void validate_nullFile_throwsFileEmpty() {
+		assertThatThrownBy(() -> fileValidator.validate(null, FileType.PROFILE_IMAGE))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException)e).getErrorCode())
+			.isEqualTo(ErrorCode.FILE_EMPTY);
+	}
+
+	@Test
+	@DisplayName("빈 파일 (isEmpty=true) - FILE_EMPTY 예외")
+	void validate_emptyFile_throwsFileEmpty() {
+		MockMultipartFile file = new MockMultipartFile("file", "empty.jpg", "image/jpeg", new byte[0]);
+		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException)e).getErrorCode())
+			.isEqualTo(ErrorCode.FILE_EMPTY);
+	}
+
+	// ────────────── 확장자 검사 ──────────────
+
+	@Test
+	@DisplayName("허용되지 않은 확장자 .exe - FILE_EXTENSION_NOT_ALLOWED 예외")
+	void validate_exeExtension_throwsExtensionNotAllowed() {
+		MockMultipartFile file = new MockMultipartFile("file", "malware.exe", "application/octet-stream",
+			new byte[1024]);
+		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException)e).getErrorCode())
+			.isEqualTo(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
+	}
+
+	@Test
+	@DisplayName("허용되지 않은 확장자 .pdf - FILE_EXTENSION_NOT_ALLOWED 예외")
+	void validate_pdfExtension_throwsExtensionNotAllowed() {
+		MockMultipartFile file = new MockMultipartFile("file", "document.pdf", "application/pdf", new byte[1024]);
+		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException)e).getErrorCode())
+			.isEqualTo(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
+	}
+
+	@Test
+	@DisplayName("확장자 없는 파일 - FILE_EXTENSION_NOT_ALLOWED 예외")
+	void validate_noExtension_throwsExtensionNotAllowed() {
+		MockMultipartFile file = new MockMultipartFile("file", "filewithoutext", "image/jpeg", new byte[1024]);
+		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException)e).getErrorCode())
+			.isEqualTo(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
+	}
+
+	// ────────────── MIME 타입 위장 공격 ──────────────
+
+	@Test
+	@DisplayName("확장자 위장 공격 - .jpg 파일이지만 PHP 바이트 - FILE_MIME_TYPE_NOT_ALLOWED 예외")
+	void validate_jpgExtensionWithPhpContent_throwsMimeNotAllowed() {
+		// PHP 파일 시작 바이트 (<?php)
+		byte[] phpBytes = "<?php echo 'malicious'; ?>".getBytes();
+		MockMultipartFile file = new MockMultipartFile("file", "fake.jpg", "image/jpeg", phpBytes);
+		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException)e).getErrorCode())
+			.isEqualTo(ErrorCode.FILE_MIME_TYPE_NOT_ALLOWED);
+	}
+
+	@Test
+	@DisplayName("확장자 위장 공격 - .jpg 파일이지만 PDF 바이트 - FILE_MIME_TYPE_NOT_ALLOWED 예외")
+	void validate_jpgExtensionWithPdfContent_throwsMimeNotAllowed() {
+		// PDF 파일 시작 바이트 (%PDF-)
+		byte[] pdfBytes = "%PDF-1.4 fake pdf content".getBytes();
+		MockMultipartFile file = new MockMultipartFile("file", "fake.jpg", "image/jpeg", pdfBytes);
+		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException)e).getErrorCode())
+			.isEqualTo(ErrorCode.FILE_MIME_TYPE_NOT_ALLOWED);
+	}
+
+	// ────────────── 파일 크기 검사 ──────────────
+
+	@Test
+	@DisplayName("프로필 이미지 5MB 초과 (6MB) - FILE_SIZE_EXCEEDED 예외")
+	void validate_profileImage6MB_throwsSizeExceeded() throws IOException {
+		MultipartFile file = createFakeJpegFile("big.jpg", 6 * 1024 * 1024);
+		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException)e).getErrorCode())
+			.isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED);
+	}
+
+	@Test
+	@DisplayName("모임 이미지 10MB 초과 (11MB) - FILE_SIZE_EXCEEDED 예외")
+	void validate_gatheringImage11MB_throwsSizeExceeded() throws IOException {
+		MultipartFile file = createFakeJpegFile("huge.jpg", 11 * 1024 * 1024);
+		assertThatThrownBy(() -> fileValidator.validate(file, FileType.GATHERING_IMAGE))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException)e).getErrorCode())
+			.isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED);
+	}
+
+	// ────────────── 헬퍼 메서드 ──────────────
+
+	/**
+	 * 실제 JPEG 매직 바이트(FF D8 FF)로 시작하는 가짜 JPEG 파일 생성
+	 */
+	private MultipartFile createFakeJpegFile(String filename, int size) {
+		byte[] content = new byte[size];
+		// JPEG 매직 바이트
+		content[0] = (byte)0xFF;
+		content[1] = (byte)0xD8;
+		content[2] = (byte)0xFF;
+		content[3] = (byte)0xE0;
+		return new MockMultipartFile("file", filename, "image/jpeg", content);
+	}
+
+	/**
+	 * 실제 PNG 매직 바이트(89 50 4E 47)로 시작하는 가짜 PNG 파일 생성
+	 */
+	private MultipartFile createFakePngFile(String filename, int size) {
+		byte[] content = new byte[size];
+		// PNG 매직 바이트
+		content[0] = (byte)0x89;
+		content[1] = (byte)0x50; // P
+		content[2] = (byte)0x4E; // N
+		content[3] = (byte)0x47; // G
+		content[4] = (byte)0x0D;
+		content[5] = (byte)0x0A;
+		content[6] = (byte)0x1A;
+		content[7] = (byte)0x0A;
+		return new MockMultipartFile("file", filename, "image/png", content);
+	}
+
+	/**
+	 * WebP 파일은 RIFF....WEBP 형식으로 시작
+	 */
+	private MultipartFile createFakeWebpFile(String filename, int size) {
+		byte[] content = new byte[Math.max(size, 12)];
+		// RIFF 헤더
+		content[0] = (byte)0x52; // R
+		content[1] = (byte)0x49; // I
+		content[2] = (byte)0x46; // F
+		content[3] = (byte)0x46; // F
+		// 파일 크기 (4바이트, little endian - 임의 값)
+		content[4] = (byte)(size & 0xFF);
+		content[5] = (byte)((size >> 8) & 0xFF);
+		content[6] = (byte)((size >> 16) & 0xFF);
+		content[7] = (byte)((size >> 24) & 0xFF);
+		// WEBP 마커
+		content[8] = (byte)0x57;  // W
+		content[9] = (byte)0x45;  // E
+		content[10] = (byte)0x42; // B
+		content[11] = (byte)0x50; // P
+		return new MockMultipartFile("file", filename, "image/webp", content);
+	}
+}

--- a/src/test/java/com/gathering/file/FileValidatorTest.java
+++ b/src/test/java/com/gathering/file/FileValidatorTest.java
@@ -14,18 +14,11 @@ import com.gathering.common.exception.BusinessException;
 import com.gathering.common.exception.ErrorCode;
 import com.gathering.file.application.FileValidator;
 import com.gathering.file.domain.model.FileType;
-import com.gathering.file.infra.FileUploadConfig;
 
 @DisplayName("FileValidator 단위 테스트")
 class FileValidatorTest {
 
-	private FileValidator fileValidator;
-
-	@BeforeEach
-	void setUp() {
-		FileUploadConfig config = new FileUploadConfig();
-		fileValidator = new FileValidator(config);
-	}
+	private final FileValidator fileValidator = new FileValidator();
 
 	// ────────────── 정상 케이스 ──────────────
 

--- a/src/test/java/com/gathering/file/FileValidatorTest.java
+++ b/src/test/java/com/gathering/file/FileValidatorTest.java
@@ -2,11 +2,18 @@ package com.gathering.file;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,197 +27,206 @@ class FileValidatorTest {
 
 	private final FileValidator fileValidator = new FileValidator();
 
-	// ────────────── 정상 케이스 ──────────────
+	// MIME 타입별 매직 바이트. ALLOWED_MIME_TYPES 에 새 타입 추가 시 여기도 추가 필요
+	private static final Map<String, byte[]> MIME_MAGIC_BYTES = Map.of(
+		"image/jpeg", new byte[] {(byte)0xFF, (byte)0xD8, (byte)0xFF, (byte)0xE0, 0, 0, 0, 0},
+		"image/png", new byte[] {(byte)0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A},
+		"image/gif", new byte[] {0x47, 0x49, 0x46, 0x38, 0x39, 0x61},
+		"image/webp", new byte[] {0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50}
+	);
 
-	@Test
-	@DisplayName("정상 JPEG 파일 (2MB) - 예외 없음")
-	void validate_validJpeg_noException() throws IOException {
-		MultipartFile file = createFakeJpegFile("photo.jpg", 2 * 1024 * 1024);
-		assertThatNoException().isThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE));
+	// ══════════════════════════════════════════════
+	// validateNotEmpty
+	// ══════════════════════════════════════════════
+
+	@Nested
+	@DisplayName("validateNotEmpty")
+	class ValidateNotEmpty {
+
+		@Test
+		@DisplayName("null 파일 → FILE_EMPTY")
+		void nullFile() {
+			assertThatThrownBy(() -> fileValidator.validateNotEmpty(null))
+				.isInstanceOf(BusinessException.class)
+				.extracting(e -> ((BusinessException)e).getErrorCode())
+				.isEqualTo(ErrorCode.FILE_EMPTY);
+		}
+
+		@Test
+		@DisplayName("빈 파일 → FILE_EMPTY")
+		void emptyFile() {
+			MockMultipartFile file = new MockMultipartFile("file", "empty.jpg", "image/jpeg", new byte[0]);
+			assertThatThrownBy(() -> fileValidator.validateNotEmpty(file))
+				.isInstanceOf(BusinessException.class)
+				.extracting(e -> ((BusinessException)e).getErrorCode())
+				.isEqualTo(ErrorCode.FILE_EMPTY);
+		}
+
+		@Test
+		@DisplayName("내용 있는 파일 → 예외 없음")
+		void validFile() {
+			MockMultipartFile file = new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[1024]);
+			assertThatNoException().isThrownBy(() -> fileValidator.validateNotEmpty(file));
+		}
 	}
 
-	@Test
-	@DisplayName("정상 PNG 파일 (1MB) - 예외 없음")
-	void validate_validPng_noException() throws IOException {
-		MultipartFile file = createFakePngFile("image.png", 1024 * 1024);
-		assertThatNoException().isThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE));
+	// ══════════════════════════════════════════════
+	// validateExtension
+	// ══════════════════════════════════════════════
+
+	@Nested
+	@DisplayName("validateExtension")
+	class ValidateExtension {
+
+		// validator 내부에서 toLowerCase() 처리하므로 소문자로만 검증
+		static Stream<String> allowedFilenames() {
+			return FileValidator.ALLOWED_EXTENSIONS.stream()
+				.map(ext -> "file." + ext);
+		}
+
+		@ParameterizedTest(name = "{0}")
+		@MethodSource("allowedFilenames")
+		@DisplayName("허용된 확장자 → 예외 없음")
+		void allowedExtensions(String filename) {
+			assertThatNoException().isThrownBy(() -> fileValidator.validateExtension(filename));
+		}
+
+		@Test
+		@DisplayName("대문자 확장자 → 예외 없음 (대소문자 구분 없음)")
+		void uppercaseExtension() {
+			assertThatNoException().isThrownBy(() -> fileValidator.validateExtension("PHOTO.JPG"));
+		}
+
+		@ParameterizedTest(name = "{0}")
+		@ValueSource(strings = {"malware.exe", "document.pdf", "script.js", "data.csv",
+			"archive.zip", "program.sh", "config.xml", "filewithoutext"})
+		@DisplayName("허용되지 않는 확장자 → FILE_EXTENSION_NOT_ALLOWED")
+		void notAllowedExtensions(String filename) {
+			assertThatThrownBy(() -> fileValidator.validateExtension(filename))
+				.isInstanceOf(BusinessException.class)
+				.extracting(e -> ((BusinessException)e).getErrorCode())
+				.isEqualTo(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
+		}
+
+		@ParameterizedTest
+		@NullSource
+		@DisplayName("null 파일명 → FILE_EXTENSION_NOT_ALLOWED")
+		void nullFilename(String filename) {
+			assertThatThrownBy(() -> fileValidator.validateExtension(filename))
+				.isInstanceOf(BusinessException.class)
+				.extracting(e -> ((BusinessException)e).getErrorCode())
+				.isEqualTo(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
+		}
 	}
 
-	@Test
-	@DisplayName("정상 WebP 파일 (3MB) - 예외 없음")
-	void validate_validWebp_noException() throws IOException {
-		MultipartFile file = createFakeWebpFile("image.webp", 3 * 1024 * 1024);
-		assertThatNoException().isThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE));
+	// ══════════════════════════════════════════════
+	// validateMimeType
+	// ══════════════════════════════════════════════
+
+	@Nested
+	@DisplayName("validateMimeType")
+	class ValidateMimeType {
+
+		// ALLOWED_MIME_TYPES 를 순회하며 각 타입의 매직 바이트로 파일 생성
+		static Stream<Arguments> allowedMimeFiles() {
+			return FileValidator.ALLOWED_MIME_TYPES.stream()
+				.map(mimeType -> {
+					byte[] magic = MIME_MAGIC_BYTES.get(mimeType);
+					byte[] content = Arrays.copyOf(magic, 1024);
+					MultipartFile file = new MockMultipartFile("file", "test", mimeType, content);
+					return Arguments.of(mimeType, file);
+				});
+		}
+
+		@Test
+		@DisplayName("null 파일 → FILE_EMPTY")
+		void nullFile() {
+			assertThatThrownBy(() -> fileValidator.validateMimeType(null))
+				.isInstanceOf(BusinessException.class)
+				.extracting(e -> ((BusinessException)e).getErrorCode())
+				.isEqualTo(ErrorCode.FILE_EMPTY);
+		}
+
+		@ParameterizedTest(name = "{0}")
+		@MethodSource("allowedMimeFiles")
+		@DisplayName("허용된 MIME 타입 → 예외 없음")
+		void allowedMimeTypes(String mimeType, MultipartFile file) {
+			assertThatNoException().isThrownBy(() -> fileValidator.validateMimeType(file));
+		}
+
+		@Test
+		@DisplayName("확장자 위장 - .jpg 파일이지만 PHP 바이트 → FILE_MIME_TYPE_NOT_ALLOWED")
+		void jpgExtensionWithPhpContent() {
+			byte[] phpBytes = "<?php echo 'malicious'; ?>".getBytes();
+			MockMultipartFile file = new MockMultipartFile("file", "fake.jpg", "image/jpeg", phpBytes);
+			assertThatThrownBy(() -> fileValidator.validateMimeType(file))
+				.isInstanceOf(BusinessException.class)
+				.extracting(e -> ((BusinessException)e).getErrorCode())
+				.isEqualTo(ErrorCode.FILE_MIME_TYPE_NOT_ALLOWED);
+		}
+
+		@Test
+		@DisplayName("확장자 위장 - .jpg 파일이지만 PDF 바이트 → FILE_MIME_TYPE_NOT_ALLOWED")
+		void jpgExtensionWithPdfContent() {
+			byte[] pdfBytes = "%PDF-1.4 fake pdf content".getBytes();
+			MockMultipartFile file = new MockMultipartFile("file", "fake.jpg", "image/jpeg", pdfBytes);
+			assertThatThrownBy(() -> fileValidator.validateMimeType(file))
+				.isInstanceOf(BusinessException.class)
+				.extracting(e -> ((BusinessException)e).getErrorCode())
+				.isEqualTo(ErrorCode.FILE_MIME_TYPE_NOT_ALLOWED);
+		}
 	}
 
-	@Test
-	@DisplayName("대문자 확장자 (PHOTO.JPG) - 예외 없음")
-	void validate_uppercaseExtension_noException() throws IOException {
-		MultipartFile file = createFakeJpegFile("PHOTO.JPG", 1024 * 1024);
-		assertThatNoException().isThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE));
-	}
+	// ══════════════════════════════════════════════
+	// validateSize
+	// ══════════════════════════════════════════════
 
-	@Test
-	@DisplayName("모임 이미지 7MB - 프로필 제한(5MB) 초과지만 모임 이미지 제한(10MB) 이내 - 예외 없음")
-	void validate_gatheringImage7MB_noException() throws IOException {
-		MultipartFile file = createFakeJpegFile("gathering.jpg", 7 * 1024 * 1024);
-		assertThatNoException().isThrownBy(() -> fileValidator.validate(file, FileType.GATHERING_IMAGE));
-	}
+	@Nested
+	@DisplayName("validateSize")
+	class ValidateSize {
 
-	// ────────────── 파일 비어있음 ──────────────
+		@Test
+		@DisplayName("null 파일 → FILE_EMPTY")
+		void nullFile() {
+			assertThatThrownBy(() -> fileValidator.validateSize(null, FileType.PROFILE_IMAGE))
+				.isInstanceOf(BusinessException.class)
+				.extracting(e -> ((BusinessException)e).getErrorCode())
+				.isEqualTo(ErrorCode.FILE_EMPTY);
+		}
 
-	@Test
-	@DisplayName("null 파일 - FILE_EMPTY 예외")
-	void validate_nullFile_throwsFileEmpty() {
-		assertThatThrownBy(() -> fileValidator.validate(null, FileType.PROFILE_IMAGE))
-			.isInstanceOf(BusinessException.class)
-			.extracting(e -> ((BusinessException)e).getErrorCode())
-			.isEqualTo(ErrorCode.FILE_EMPTY);
-	}
+		@Test
+		@DisplayName("null fileType → FILE_UPLOAD_FAILED")
+		void nullFileType() {
+			MockMultipartFile file = new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[1024]);
+			assertThatThrownBy(() -> fileValidator.validateSize(file, null))
+				.isInstanceOf(BusinessException.class)
+				.extracting(e -> ((BusinessException)e).getErrorCode())
+				.isEqualTo(ErrorCode.FILE_UPLOAD_FAILED);
+		}
 
-	@Test
-	@DisplayName("빈 파일 (isEmpty=true) - FILE_EMPTY 예외")
-	void validate_emptyFile_throwsFileEmpty() {
-		MockMultipartFile file = new MockMultipartFile("file", "empty.jpg", "image/jpeg", new byte[0]);
-		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
-			.isInstanceOf(BusinessException.class)
-			.extracting(e -> ((BusinessException)e).getErrorCode())
-			.isEqualTo(ErrorCode.FILE_EMPTY);
-	}
+		// FileType.values() 전체 × 경계값 3가지 조합
+		static Stream<Arguments> sizeBoundaryTestCases() {
+			return Stream.of(FileType.values()).flatMap(fileType -> Stream.of(
+				Arguments.of(fileType, fileType.getMaxSize() - 1, "maxSize-1", true),
+				Arguments.of(fileType, fileType.getMaxSize(), "maxSize", true),
+				Arguments.of(fileType, fileType.getMaxSize() + 1, "maxSize+1", false)
+			));
+		}
 
-	// ────────────── 확장자 검사 ──────────────
-
-	@Test
-	@DisplayName("허용되지 않은 확장자 .exe - FILE_EXTENSION_NOT_ALLOWED 예외")
-	void validate_exeExtension_throwsExtensionNotAllowed() {
-		MockMultipartFile file = new MockMultipartFile("file", "malware.exe", "application/octet-stream",
-			new byte[1024]);
-		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
-			.isInstanceOf(BusinessException.class)
-			.extracting(e -> ((BusinessException)e).getErrorCode())
-			.isEqualTo(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
-	}
-
-	@Test
-	@DisplayName("허용되지 않은 확장자 .pdf - FILE_EXTENSION_NOT_ALLOWED 예외")
-	void validate_pdfExtension_throwsExtensionNotAllowed() {
-		MockMultipartFile file = new MockMultipartFile("file", "document.pdf", "application/pdf", new byte[1024]);
-		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
-			.isInstanceOf(BusinessException.class)
-			.extracting(e -> ((BusinessException)e).getErrorCode())
-			.isEqualTo(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
-	}
-
-	@Test
-	@DisplayName("확장자 없는 파일 - FILE_EXTENSION_NOT_ALLOWED 예외")
-	void validate_noExtension_throwsExtensionNotAllowed() {
-		MockMultipartFile file = new MockMultipartFile("file", "filewithoutext", "image/jpeg", new byte[1024]);
-		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
-			.isInstanceOf(BusinessException.class)
-			.extracting(e -> ((BusinessException)e).getErrorCode())
-			.isEqualTo(ErrorCode.FILE_EXTENSION_NOT_ALLOWED);
-	}
-
-	// ────────────── MIME 타입 위장 공격 ──────────────
-
-	@Test
-	@DisplayName("확장자 위장 공격 - .jpg 파일이지만 PHP 바이트 - FILE_MIME_TYPE_NOT_ALLOWED 예외")
-	void validate_jpgExtensionWithPhpContent_throwsMimeNotAllowed() {
-		// PHP 파일 시작 바이트 (<?php)
-		byte[] phpBytes = "<?php echo 'malicious'; ?>".getBytes();
-		MockMultipartFile file = new MockMultipartFile("file", "fake.jpg", "image/jpeg", phpBytes);
-		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
-			.isInstanceOf(BusinessException.class)
-			.extracting(e -> ((BusinessException)e).getErrorCode())
-			.isEqualTo(ErrorCode.FILE_MIME_TYPE_NOT_ALLOWED);
-	}
-
-	@Test
-	@DisplayName("확장자 위장 공격 - .jpg 파일이지만 PDF 바이트 - FILE_MIME_TYPE_NOT_ALLOWED 예외")
-	void validate_jpgExtensionWithPdfContent_throwsMimeNotAllowed() {
-		// PDF 파일 시작 바이트 (%PDF-)
-		byte[] pdfBytes = "%PDF-1.4 fake pdf content".getBytes();
-		MockMultipartFile file = new MockMultipartFile("file", "fake.jpg", "image/jpeg", pdfBytes);
-		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
-			.isInstanceOf(BusinessException.class)
-			.extracting(e -> ((BusinessException)e).getErrorCode())
-			.isEqualTo(ErrorCode.FILE_MIME_TYPE_NOT_ALLOWED);
-	}
-
-	// ────────────── 파일 크기 검사 ──────────────
-
-	@Test
-	@DisplayName("프로필 이미지 5MB 초과 (6MB) - FILE_SIZE_EXCEEDED 예외")
-	void validate_profileImage6MB_throwsSizeExceeded() throws IOException {
-		MultipartFile file = createFakeJpegFile("big.jpg", 6 * 1024 * 1024);
-		assertThatThrownBy(() -> fileValidator.validate(file, FileType.PROFILE_IMAGE))
-			.isInstanceOf(BusinessException.class)
-			.extracting(e -> ((BusinessException)e).getErrorCode())
-			.isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED);
-	}
-
-	@Test
-	@DisplayName("모임 이미지 10MB 초과 (11MB) - FILE_SIZE_EXCEEDED 예외")
-	void validate_gatheringImage11MB_throwsSizeExceeded() throws IOException {
-		MultipartFile file = createFakeJpegFile("huge.jpg", 11 * 1024 * 1024);
-		assertThatThrownBy(() -> fileValidator.validate(file, FileType.GATHERING_IMAGE))
-			.isInstanceOf(BusinessException.class)
-			.extracting(e -> ((BusinessException)e).getErrorCode())
-			.isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED);
-	}
-
-	// ────────────── 헬퍼 메서드 ──────────────
-
-	/**
-	 * 실제 JPEG 매직 바이트(FF D8 FF)로 시작하는 가짜 JPEG 파일 생성
-	 */
-	private MultipartFile createFakeJpegFile(String filename, int size) {
-		byte[] content = new byte[size];
-		// JPEG 매직 바이트
-		content[0] = (byte)0xFF;
-		content[1] = (byte)0xD8;
-		content[2] = (byte)0xFF;
-		content[3] = (byte)0xE0;
-		return new MockMultipartFile("file", filename, "image/jpeg", content);
-	}
-
-	/**
-	 * 실제 PNG 매직 바이트(89 50 4E 47)로 시작하는 가짜 PNG 파일 생성
-	 */
-	private MultipartFile createFakePngFile(String filename, int size) {
-		byte[] content = new byte[size];
-		// PNG 매직 바이트
-		content[0] = (byte)0x89;
-		content[1] = (byte)0x50; // P
-		content[2] = (byte)0x4E; // N
-		content[3] = (byte)0x47; // G
-		content[4] = (byte)0x0D;
-		content[5] = (byte)0x0A;
-		content[6] = (byte)0x1A;
-		content[7] = (byte)0x0A;
-		return new MockMultipartFile("file", filename, "image/png", content);
-	}
-
-	/**
-	 * WebP 파일은 RIFF....WEBP 형식으로 시작
-	 */
-	private MultipartFile createFakeWebpFile(String filename, int size) {
-		byte[] content = new byte[Math.max(size, 12)];
-		// RIFF 헤더
-		content[0] = (byte)0x52; // R
-		content[1] = (byte)0x49; // I
-		content[2] = (byte)0x46; // F
-		content[3] = (byte)0x46; // F
-		// 파일 크기 (4바이트, little endian - 임의 값)
-		content[4] = (byte)(size & 0xFF);
-		content[5] = (byte)((size >> 8) & 0xFF);
-		content[6] = (byte)((size >> 16) & 0xFF);
-		content[7] = (byte)((size >> 24) & 0xFF);
-		// WEBP 마커
-		content[8] = (byte)0x57;  // W
-		content[9] = (byte)0x45;  // E
-		content[10] = (byte)0x42; // B
-		content[11] = (byte)0x50; // P
-		return new MockMultipartFile("file", filename, "image/webp", content);
+		@ParameterizedTest(name = "[{0}] {2}")
+		@MethodSource("sizeBoundaryTestCases")
+		@DisplayName("파일 크기 경계값")
+		void sizeBoundary(FileType fileType, long size, String label, boolean shouldPass) {
+			byte[] content = new byte[(int)size];
+			MockMultipartFile file = new MockMultipartFile("file", "photo.jpg", "image/jpeg", content);
+			if (shouldPass) {
+				assertThatNoException().isThrownBy(() -> fileValidator.validateSize(file, fileType));
+			} else {
+				assertThatThrownBy(() -> fileValidator.validateSize(file, fileType))
+					.isInstanceOf(BusinessException.class)
+					.extracting(e -> ((BusinessException)e).getErrorCode())
+					.isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED);
+			}
+		}
 	}
 }

--- a/src/test/java/com/gathering/file/LocalStorageServiceTest.java
+++ b/src/test/java/com/gathering/file/LocalStorageServiceTest.java
@@ -1,0 +1,110 @@
+package com.gathering.file;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.gathering.file.application.StorageResult;
+import com.gathering.file.infra.FileUploadConfig;
+import com.gathering.file.infra.LocalStorageService;
+
+@DisplayName("LocalStorageService 단위 테스트")
+class LocalStorageServiceTest {
+
+	@TempDir
+	Path tempDir;
+
+	private LocalStorageService localStorageService;
+
+	@BeforeEach
+	void setUp() {
+		FileUploadConfig config = new FileUploadConfig();
+		config.setLocalUploadPath(tempDir.toString());
+		config.setUrlPrefix("/uploads");
+		localStorageService = new LocalStorageService(config);
+	}
+
+	@Test
+	@DisplayName("파일 저장 - UUID 이름으로 디렉토리에 파일이 생성된다")
+	void store_validFile_createsFileOnDisk() throws IOException {
+		byte[] content = createJpegBytes();
+		MultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", content);
+
+		StorageResult result = localStorageService.store(file, "profile-images");
+
+		Path expectedDir = tempDir.resolve("profile-images");
+		assertThat(expectedDir).isDirectory();
+		assertThat(result.storedFilename()).endsWith(".jpg");
+		assertThat(result.publicUrl()).startsWith("/uploads/profile-images/");
+		assertThat(result.storagePath()).startsWith("profile-images/");
+
+		// 실제 파일이 존재하는지 확인
+		Path storedFile = tempDir.resolve(result.storagePath());
+		assertThat(storedFile).exists();
+	}
+
+	@Test
+	@DisplayName("파일 저장 - 저장된 파일의 내용이 원본과 동일하다")
+	void store_validFile_contentMatches() throws IOException {
+		byte[] content = createJpegBytes();
+		MultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", content);
+
+		StorageResult result = localStorageService.store(file, "profile-images");
+		Path storedFile = tempDir.resolve(result.storagePath());
+
+		byte[] storedContent = Files.readAllBytes(storedFile);
+		assertThat(storedContent).isEqualTo(content);
+	}
+
+	@Test
+	@DisplayName("파일 삭제 - 저장된 파일이 디스크에서 제거된다")
+	void delete_existingFile_removesFromDisk() throws IOException {
+		byte[] content = createJpegBytes();
+		MultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", content);
+		StorageResult result = localStorageService.store(file, "profile-images");
+
+		Path storedFile = tempDir.resolve(result.storagePath());
+		assertThat(storedFile).exists();
+
+		localStorageService.delete(result.storagePath());
+
+		assertThat(storedFile).doesNotExist();
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 파일 삭제 - 예외 없이 처리된다 (idempotent)")
+	void delete_nonExistentFile_noException() {
+		assertThatNoException().isThrownBy(() -> localStorageService.delete("profile-images/nonexistent.jpg"));
+	}
+
+	@Test
+	@DisplayName("저장 디렉토리가 없을 때 - 자동으로 생성된다")
+	void store_directoryNotExists_createsDirectory() throws IOException {
+		byte[] content = createJpegBytes();
+		MultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", content);
+
+		// 존재하지 않는 하위 디렉토리 지정
+		localStorageService.store(file, "new-dir/sub-dir");
+
+		Path newDir = tempDir.resolve("new-dir/sub-dir");
+		assertThat(newDir).isDirectory();
+	}
+
+	private byte[] createJpegBytes() {
+		byte[] content = new byte[1024];
+		content[0] = (byte)0xFF;
+		content[1] = (byte)0xD8;
+		content[2] = (byte)0xFF;
+		content[3] = (byte)0xE0;
+		return content;
+	}
+}

--- a/src/test/java/com/gathering/file/application/FileValidatorTest.java
+++ b/src/test/java/com/gathering/file/application/FileValidatorTest.java
@@ -1,4 +1,4 @@
-package com.gathering.file;
+package com.gathering.file.application;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -19,7 +19,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.gathering.common.exception.BusinessException;
 import com.gathering.common.exception.ErrorCode;
-import com.gathering.file.application.FileValidator;
 import com.gathering.file.domain.model.FileType;
 
 @DisplayName("FileValidator 단위 테스트")

--- a/src/test/java/com/gathering/gathering/GatheringImageUploadControllerTest.java
+++ b/src/test/java/com/gathering/gathering/GatheringImageUploadControllerTest.java
@@ -1,0 +1,194 @@
+package com.gathering.gathering;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.gathering.auth.application.AuthService;
+import com.gathering.auth.infra.JwtTokenProvider;
+import com.gathering.common.exception.BusinessException;
+import com.gathering.common.exception.ErrorCode;
+import com.gathering.gathering.application.GatheringService;
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("PATCH /gatherings/{tsid}/main-image 통합 테스트")
+class GatheringImageUploadControllerTest {
+
+	@TestConfiguration
+	static class TestConfig {
+
+		@Bean
+		@Primary
+		public GatheringService gatheringService() {
+			return Mockito.mock(GatheringService.class);
+		}
+
+		@Bean
+		@Primary
+		public AuthService authService() {
+			return Mockito.mock(AuthService.class);
+		}
+
+		@Bean
+		@Primary
+		public JwtTokenProvider jwtTokenProvider() {
+			return Mockito.mock(JwtTokenProvider.class);
+		}
+	}
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private GatheringService gatheringService;
+
+	@Autowired
+	private AuthService authService;
+
+	private static final String GATHERING_TSID = "gatheringTsid0";
+	private static final String USER_TSID = "testUserTsid00";
+	private static final String IMAGE_URL = "/uploads/gathering-images/uuid.jpg";
+
+	@BeforeEach
+	void setUp() {
+		Mockito.reset(gatheringService, authService);
+		given(authService.getCurrentUserTsid(any())).willReturn(USER_TSID);
+	}
+
+	@Test
+	@DisplayName("모임 OWNER가 유효한 이미지 업로드 - 200 OK")
+	void uploadMainImage_ownerUploads_returns200() throws Exception {
+		// given
+		MockMultipartFile file = createValidJpegFile("banner.jpg");
+		given(gatheringService.uploadMainImage(eq(GATHERING_TSID), eq(USER_TSID), any())).willReturn(IMAGE_URL);
+
+		// when & then
+		mockMvc.perform(multipart("/gatherings/{tsid}/main-image", GATHERING_TSID)
+				.file(file)
+				.with(req -> {
+					req.setMethod("PATCH");
+					return req;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.url").value(IMAGE_URL))
+			.andDo(document("gatherings-upload-main-image",
+				pathParameters(
+					parameterWithName("tsid").description("모임 TSID")
+				),
+				responseFields(
+					fieldWithPath("url").description("업로드된 모임 대표 이미지 URL")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("OWNER 권한 없는 사용자 - 403 Forbidden")
+	void uploadMainImage_notOwner_returns403() throws Exception {
+		// given
+		MockMultipartFile file = createValidJpegFile("banner.jpg");
+		given(gatheringService.uploadMainImage(eq(GATHERING_TSID), eq(USER_TSID), any()))
+			.willThrow(new BusinessException(ErrorCode.GATHERING_ACCESS_DENIED));
+
+		// when & then
+		mockMvc.perform(multipart("/gatherings/{tsid}/main-image", GATHERING_TSID)
+				.file(file)
+				.with(req -> {
+					req.setMethod("PATCH");
+					return req;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("GATHERING_ACCESS_DENIED"));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 모임 - 404 Not Found")
+	void uploadMainImage_gatheringNotFound_returns404() throws Exception {
+		// given
+		MockMultipartFile file = createValidJpegFile("banner.jpg");
+		given(gatheringService.uploadMainImage(eq(GATHERING_TSID), eq(USER_TSID), any()))
+			.willThrow(new BusinessException(ErrorCode.GATHERING_NOT_FOUND));
+
+		// when & then
+		mockMvc.perform(multipart("/gatherings/{tsid}/main-image", GATHERING_TSID)
+				.file(file)
+				.with(req -> {
+					req.setMethod("PATCH");
+					return req;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("GATHERING_NOT_FOUND"));
+	}
+
+	@Test
+	@DisplayName("10MB 초과 파일 - 400 Bad Request, FILE_SIZE_EXCEEDED")
+	void uploadMainImage_fileSizeExceeded_returns400() throws Exception {
+		// given
+		MockMultipartFile bigFile = createValidJpegFile("big.jpg");
+		given(gatheringService.uploadMainImage(eq(GATHERING_TSID), eq(USER_TSID), any()))
+			.willThrow(new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED));
+
+		// when & then
+		mockMvc.perform(multipart("/gatherings/{tsid}/main-image", GATHERING_TSID)
+				.file(bigFile)
+				.with(req -> {
+					req.setMethod("PATCH");
+					return req;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("FILE_SIZE_EXCEEDED"));
+	}
+
+	@Test
+	@DisplayName("허용되지 않은 확장자 - 400 Bad Request, FILE_EXTENSION_NOT_ALLOWED")
+	void uploadMainImage_invalidExtension_returns400() throws Exception {
+		// given
+		MockMultipartFile pdfFile = new MockMultipartFile("file", "document.pdf", "application/pdf", new byte[1024]);
+		given(gatheringService.uploadMainImage(eq(GATHERING_TSID), eq(USER_TSID), any()))
+			.willThrow(new BusinessException(ErrorCode.FILE_EXTENSION_NOT_ALLOWED));
+
+		// when & then
+		mockMvc.perform(multipart("/gatherings/{tsid}/main-image", GATHERING_TSID)
+				.file(pdfFile)
+				.with(req -> {
+					req.setMethod("PATCH");
+					return req;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("FILE_EXTENSION_NOT_ALLOWED"));
+	}
+
+	private MockMultipartFile createValidJpegFile(String filename) {
+		byte[] content = new byte[1024];
+		content[0] = (byte)0xFF;
+		content[1] = (byte)0xD8;
+		content[2] = (byte)0xFF;
+		content[3] = (byte)0xE0;
+		return new MockMultipartFile("file", filename, "image/jpeg", content);
+	}
+}

--- a/src/test/java/com/gathering/user/UserProfileImageUploadControllerTest.java
+++ b/src/test/java/com/gathering/user/UserProfileImageUploadControllerTest.java
@@ -1,0 +1,211 @@
+package com.gathering.user;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.gathering.auth.application.AuthService;
+import com.gathering.auth.infra.JwtTokenProvider;
+import com.gathering.common.exception.BusinessException;
+import com.gathering.common.exception.ErrorCode;
+import com.gathering.user.application.UserService;
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("PATCH /users/me/profile-image 통합 테스트")
+class UserProfileImageUploadControllerTest {
+
+	@TestConfiguration
+	static class TestConfig {
+
+		@Bean
+		@Primary
+		public UserService userService() {
+			return Mockito.mock(UserService.class);
+		}
+
+		@Bean
+		@Primary
+		public AuthService authService() {
+			return Mockito.mock(AuthService.class);
+		}
+
+		@Bean
+		@Primary
+		public JwtTokenProvider jwtTokenProvider() {
+			return Mockito.mock(JwtTokenProvider.class);
+		}
+	}
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private UserService userService;
+
+	@Autowired
+	private AuthService authService;
+
+	private static final String USER_TSID = "testUserTsid00";
+	private static final String PROFILE_IMAGE_URL = "/uploads/profile-images/uuid.jpg";
+
+	@BeforeEach
+	void setUp() {
+		Mockito.reset(userService, authService);
+		given(authService.getCurrentUserTsid(any())).willReturn(USER_TSID);
+	}
+
+	@Test
+	@DisplayName("유효한 JPEG 파일 업로드 - 200 OK, URL 반환")
+	void uploadProfileImage_validJpeg_returns200() throws Exception {
+		// given
+		MockMultipartFile file = createValidJpegFile("photo.jpg");
+		given(userService.uploadProfileImage(eq(USER_TSID), any())).willReturn(PROFILE_IMAGE_URL);
+
+		// when & then
+		mockMvc.perform(multipart("/users/me/profile-image")
+				.file(file)
+				.with(req -> {
+					req.setMethod("PATCH");
+					return req;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.url").value(PROFILE_IMAGE_URL))
+			.andDo(document("users-upload-profile-image",
+				responseFields(
+					fieldWithPath("url").description("업로드된 프로필 이미지 URL")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("빈 파일 업로드 - 400 Bad Request, FILE_EMPTY")
+	void uploadProfileImage_emptyFile_returns400() throws Exception {
+		// given
+		MockMultipartFile emptyFile = new MockMultipartFile("file", "empty.jpg", "image/jpeg", new byte[0]);
+		given(userService.uploadProfileImage(eq(USER_TSID), any()))
+			.willThrow(new BusinessException(ErrorCode.FILE_EMPTY));
+
+		// when & then
+		mockMvc.perform(multipart("/users/me/profile-image")
+				.file(emptyFile)
+				.with(req -> {
+					req.setMethod("PATCH");
+					return req;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("FILE_EMPTY"));
+	}
+
+	@Test
+	@DisplayName("허용되지 않은 확장자 - 400 Bad Request, FILE_EXTENSION_NOT_ALLOWED")
+	void uploadProfileImage_invalidExtension_returns400() throws Exception {
+		// given
+		MockMultipartFile pdfFile = new MockMultipartFile("file", "document.pdf", "application/pdf", new byte[1024]);
+		given(userService.uploadProfileImage(eq(USER_TSID), any()))
+			.willThrow(new BusinessException(ErrorCode.FILE_EXTENSION_NOT_ALLOWED));
+
+		// when & then
+		mockMvc.perform(multipart("/users/me/profile-image")
+				.file(pdfFile)
+				.with(req -> {
+					req.setMethod("PATCH");
+					return req;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("FILE_EXTENSION_NOT_ALLOWED"));
+	}
+
+	@Test
+	@DisplayName("파일 크기 초과 - 400 Bad Request, FILE_SIZE_EXCEEDED")
+	void uploadProfileImage_fileSizeExceeded_returns400() throws Exception {
+		// given
+		MockMultipartFile bigFile = new MockMultipartFile("file", "big.jpg", "image/jpeg", new byte[1024]);
+		given(userService.uploadProfileImage(eq(USER_TSID), any()))
+			.willThrow(new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED));
+
+		// when & then
+		mockMvc.perform(multipart("/users/me/profile-image")
+				.file(bigFile)
+				.with(req -> {
+					req.setMethod("PATCH");
+					return req;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("FILE_SIZE_EXCEEDED"));
+	}
+
+	@Test
+	@DisplayName("MIME 타입 위장 파일 - 400 Bad Request, FILE_MIME_TYPE_NOT_ALLOWED")
+	void uploadProfileImage_mimeSpoofed_returns400() throws Exception {
+		// given
+		MockMultipartFile spoofedFile = new MockMultipartFile("file", "fake.jpg", "image/jpeg",
+			"<?php echo 'xss'; ?>".getBytes());
+		given(userService.uploadProfileImage(eq(USER_TSID), any()))
+			.willThrow(new BusinessException(ErrorCode.FILE_MIME_TYPE_NOT_ALLOWED));
+
+		// when & then
+		mockMvc.perform(multipart("/users/me/profile-image")
+				.file(spoofedFile)
+				.with(req -> {
+					req.setMethod("PATCH");
+					return req;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("FILE_MIME_TYPE_NOT_ALLOWED"));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 사용자 - 404 Not Found")
+	void uploadProfileImage_userNotFound_returns404() throws Exception {
+		// given
+		MockMultipartFile file = createValidJpegFile("photo.jpg");
+		given(userService.uploadProfileImage(eq(USER_TSID), any()))
+			.willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		// when & then
+		mockMvc.perform(multipart("/users/me/profile-image")
+				.file(file)
+				.with(req -> {
+					req.setMethod("PATCH");
+					return req;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+	}
+
+	private MockMultipartFile createValidJpegFile(String filename) {
+		byte[] content = new byte[1024];
+		content[0] = (byte)0xFF;
+		content[1] = (byte)0xD8;
+		content[2] = (byte)0xFF;
+		content[3] = (byte)0xE0;
+		return new MockMultipartFile("file", filename, "image/jpeg", content);
+	}
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -41,6 +41,11 @@ spring:
             client-id: id
             client-secret: secret
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 crypto:
   aes:
     key: gatheringkey1234
@@ -49,3 +54,8 @@ jwt:
   secret: gatheringSecretKeyForJwtTokenGenerationMustBeLongEnoughForHS256Algorithm
   access-token-validity-in-seconds: 3600 # 1시간
   refresh-token-validity-in-seconds: 7776000 # 90일
+
+file:
+  upload:
+    local-upload-path: /tmp/gathering-test-uploads
+    url-prefix: /uploads


### PR DESCRIPTION
Closes #26

## 🎯 요약 (Summary)

프로필 이미지 및 모임 이미지 업로드 기능을 구현합니다.

* **무엇을 변경했나**: 파일 업로드 도메인(`file`) 신규 구현, 프로필/모임 이미지 업로드·삭제 API 추가, 내 정보 페이지에 이미지 업로드 UI 연동
* **왜 필요한가**: 사용자 식별성과 모임 정보의 시각적 표현을 위해 이미지 업로드 기능이 필요. 이슈 #26에서 논의된 이미지 저장 전략을 구체화하여, 로컬/테스트 환경은 로컬 디스크, 운영 환경은 S3로 전환 가능한 구조로 설계

---

## 💡 유즈 케이스 (Use Case)

### 프로필 이미지 업로드
```
use case: 프로필 이미지 업로드
성공: 유효한 이미지 파일을 업로드하면 URL이 반환되고 사용자 정보에 반영된다.
실패
  - 파일이 비어있는 경우 업로드에 실패한다.
  - 허용되지 않는 확장자(exe, pdf 등)인 경우 업로드에 실패한다.
  - 확장자를 위장한 파일(PHP 바이트를 .jpg로 위장)인 경우 업로드에 실패한다.
  - 파일 크기가 제한(5MB)을 초과하면 업로드에 실패한다.
```

### 파일 검증 (FileValidator)
```
use case: 파일 유효성 검사
- validateNotEmpty: null/빈 파일 거부
- validateExtension: 허용 확장자(jpg, jpeg, png, gif, webp) 소문자/대문자 모두 허용, 미허용 확장자 거부
- validateMimeType: Apache Tika로 실제 바이트 감지, 허용 MIME 타입 검증, 확장자 위장 공격 차단
- validateSize: FileType별 maxSize 경계값(maxSize-1, maxSize, maxSize+1) 검증
```

* 새로 작성한 테스트 목록:
  * `FileValidatorTest` — validateNotEmpty / validateExtension / validateMimeType / validateSize 단위 테스트 (파라미터화)
  * `FileUploadServiceTest` — 업로드 성공/실패/롤백 시 파일 삭제 시나리오
  * `LocalStorageServiceTest` — 로컬 저장소 store/delete 테스트
  * `UserProfileImageUploadControllerTest` — 프로필 이미지 업로드 통합 테스트
  * `GatheringImageUploadControllerTest` — 모임 이미지 업로드 통합 테스트

---

## 🧱 변경 사항 및 변경 맥락 (Changes & Rationale)

**파일 업로드 도메인 설계**
```
AS_IS: 파일 업로드 기능 없음
TO_BE: file 도메인 신규 구현 (FileUploadService, FileValidator, StorageService 인터페이스)
REASON: 향후 S3 전환을 고려해 StorageService를 인터페이스로 추상화. 프로파일(default/test → LocalStorageService, prod → S3StorageService)로 환경별 구현체를 분리
```

**MIME 타입 위장 공격 방어**
```
AS_IS: 확장자만 검사
TO_BE: Apache Tika로 실제 파일 바이트를 읽어 MIME 타입 감지
REASON: .jpg로 위장한 PHP/PDF 파일 업로드 공격 차단
```

**이미지 교체 시 구 파일 정리**
```
AS_IS: 새 이미지 업로드 시 기존 파일이 스토리지에 남아있음
TO_BE: 트랜잭션 커밋 이후 기존 파일 삭제 (afterCommit 콜백)
REASON: 커밋 전 삭제 시 새 이미지 업로드 실패/롤백 시 기존 이미지도 유실되는 문제 방지
```

**프로필 이미지 삭제 기능**
```
AS_IS: 프로필 이미지 초기화 방법 없음
TO_BE: DELETE /users/me/profile-image API + UI 삭제 버튼(✕) 추가
REASON: 사용자가 프로필 이미지를 초기화하고 싶은 경우를 위한 기능
```

---

## ✅ 체크리스트 (Checklist)

- [x] 테스트가 모두 통과한다
- [x] 빌드가 성공한다
- [x] 불필요한 변수, 메서드, import 가 제거되었다
- [x] checkstyle, formatter 등 코드 규칙을 정확히 준수했다

---

## 📎 기타 참고 사항

* **S3 미구현**: `S3StorageService`는 스텁 상태로, 운영 배포 전 AWS SDK v2 구현 필요 (CloudFront OAC 연동 포함)
* **로컬 저장 경로**: `application.yaml`의 `file.upload.local-upload-path` 설정값 기준 절대 경로로 저장 (기본값: 프로젝트 루트 `/uploads`)
* **파일 크기 제한**: 프로필 이미지 5MB, 모임 이미지 10MB. `FileType` enum에서 관리하므로 변경 시 한 곳만 수정